### PR TITLE
Fix Align Features: word-level JSON at transcript time (v1.0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,11 @@ venv/
 
 # Pretrained models
 /pretrained_models/
+
+# Agent cofig
+.cursor/
+CONTEXT.md
+
+# Testing Workflows
+/audio-test
+/pose-test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multisocial-toolbox"
-version = "1.0.0"
+version = "1.0.1"
 description = "Desktop toolbox for multimodal interaction analysis across video and audio."
 readme = "README.md"
 requires-python = ">=3.10,<3.11"

--- a/src/app.py
+++ b/src/app.py
@@ -292,6 +292,14 @@ class VideoToWavConverter(wx.Frame):
         gui_utils.style_checkbox_for_glass(self.diarizationCheckbox)
         audio_sizer.Add(self.diarizationCheckbox, flag=wx.ALIGN_CENTER|wx.ALL, border=6)
 
+        # Word-level timestamps (precomputes the JSON sidecar that Align Features needs,
+        # so alignment doesn't have to re-run transcription on every file later)
+        self.wordTimestampsCheckbox = wx.CheckBox(self.audioPanel, label="Save word-level timestamps (for Align Features)")
+        self.wordTimestampsCheckbox.SetFont(Theme.get_font(12))
+        self.wordTimestampsCheckbox.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
+        gui_utils.style_checkbox_for_glass(self.wordTimestampsCheckbox)
+        audio_sizer.Add(self.wordTimestampsCheckbox, flag=wx.ALIGN_CENTER|wx.ALL, border=6)
+
         self.diarizationStatusLabel = gui_utils.create_transparent_text(
             self.audioPanel,
             label="Diarization status: checking optional component...",
@@ -613,6 +621,8 @@ class VideoToWavConverter(wx.Frame):
                 self.multiPersonCheckbox.SetFont(self._scale_font(14, scale))
             if hasattr(self, 'diarizationCheckbox') and self.diarizationCheckbox:
                 self.diarizationCheckbox.SetFont(self._scale_font(12, scale))
+            if hasattr(self, 'wordTimestampsCheckbox') and self.wordTimestampsCheckbox:
+                self.wordTimestampsCheckbox.SetFont(self._scale_font(12, scale))
             if hasattr(self, 'diarizationStatusLabel') and self.diarizationStatusLabel:
                 self.diarizationStatusLabel.SetFont(self._scale_font(11, scale))
                 try:
@@ -1321,19 +1331,30 @@ class VideoToWavConverter(wx.Frame):
                 )
                 audio_processor.enable_speaker_diarization = False
 
+        # Word-level timestamps are opt-in: they precompute the JSON sidecar Align Features
+        # needs, so alignment doesn't have to re-run transcription file-by-file later.
+        word_timestamps = bool(
+            hasattr(self, 'wordTimestampsCheckbox') and self.wordTimestampsCheckbox.GetValue()
+        )
+
         # Run transcription in a separate thread
-        thread = threading.Thread(target=self.extract_transcripts_batch, args=(audio_files, audio_processor))
+        thread = threading.Thread(
+            target=self.extract_transcripts_batch,
+            args=(audio_files, audio_processor, word_timestamps),
+        )
         thread.start()
 
 
-    def extract_transcripts_batch(self, audio_files, audio_processor):
+    def extract_transcripts_batch(self, audio_files, audio_processor, word_timestamps=False):
         """Batch process all audio files to generate transcripts."""
         self._process_running = True
         try:
             def progress_callback(progress):
                 self.update_progress(progress)
-            
-            audio_processor.extract_transcripts_batch(audio_files, progress_callback=progress_callback)
+
+            audio_processor.extract_transcripts_batch(
+                audio_files, progress_callback=progress_callback, word_timestamps=word_timestamps
+            )
             wx.CallAfter(wx.MessageBox, "Transcription extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
         except Exception as e:
             wx.CallAfter(wx.MessageBox, f"Error during transcript extraction: {e}", "Error", wx.OK | wx.ICON_ERROR)
@@ -1381,10 +1402,11 @@ class VideoToWavConverter(wx.Frame):
             )
             
             alignment_pairs = []
-            
+            prep_errors = []  # (base_name, reason) for files we couldn't prepare
+
             for i, audio_file in enumerate(audio_files, start=1):
                 base_name = os.path.splitext(os.path.basename(audio_file))[0]
-                
+
                 # 1. Ensure we have word-level transcript (JSON)
                 json_path = os.path.join(self.extracted_transcripts_folder, f"{base_name}_words.json")
                 if not os.path.exists(json_path):
@@ -1394,8 +1416,15 @@ class VideoToWavConverter(wx.Frame):
                         audio_processor.extract_transcript(audio_file, word_timestamps=True)
                     except Exception as e:
                         print(f"Failed to generate transcript for {base_name}: {e}")
+                        prep_errors.append((base_name, f"transcript failed: {e}"))
                         continue
-                
+                    # extract_transcript only warns (doesn't raise) if the JSON can't be
+                    # written, so confirm the sidecar actually exists before pairing it.
+                    if not os.path.exists(json_path):
+                        print(f"Word-level JSON was not produced for {base_name}; skipping.")
+                        prep_errors.append((base_name, "word-level JSON was not produced"))
+                        continue
+
                 # 2. Ensure we have features CSV
                 # Feature files are usually named {base_name}.csv or similar in extracted_audio_folder
                 # The AudioProcessor.extract_audio_features saves them as {base_name}.csv
@@ -1408,28 +1437,41 @@ class VideoToWavConverter(wx.Frame):
                         # Verify the file was created
                         if not os.path.exists(feature_csv):
                             print(f"Feature extraction completed but file not found: {feature_csv}, skipping.")
+                            prep_errors.append((base_name, "feature CSV was not produced"))
                             continue
                     except Exception as e:
                         print(f"Failed to extract features for {base_name}: {e}")
+                        prep_errors.append((base_name, f"feature extraction failed: {e}"))
                         continue
-                        
+
                 # 3. Output path
                 output_csv = os.path.join(self.extracted_audio_folder, f"{base_name}_aligned.csv")
                 alignment_pairs.append((feature_csv, json_path, output_csv))
-                
+
                 self.update_progress(int((i / total_files) * 50)) # First 50% for prep
 
             if not alignment_pairs:
-                wx.CallAfter(wx.MessageBox, "No valid pairs found to align. Ensure you have extracted audio features.", "Warning", wx.OK | wx.ICON_WARNING)
+                detail = "\n".join(f"• {name}: {reason}" for name, reason in prep_errors[:10])
+                if len(prep_errors) > 10:
+                    detail += f"\n…and {len(prep_errors) - 10} more (see console/log)."
+                message = "No valid pairs found to align. Ensure you have extracted audio features."
+                if detail:
+                    message += "\n\nWhat went wrong:\n" + detail
+                wx.CallAfter(wx.MessageBox, message, "Warning", wx.OK | wx.ICON_WARNING)
                 return
 
             # Run alignment
             audio_processor.align_features_batch(
-                alignment_pairs, 
+                alignment_pairs,
                 progress_callback=lambda p: self.update_progress(50 + int(p/2))
             )
-            
-            wx.CallAfter(wx.MessageBox, "Feature alignment completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+
+            success_message = f"Feature alignment completed for {len(alignment_pairs)} file(s)!"
+            if prep_errors:
+                success_message += (
+                    f"\n\n{len(prep_errors)} file(s) were skipped (see console/log for details)."
+                )
+            wx.CallAfter(wx.MessageBox, success_message, "Success", wx.OK | wx.ICON_INFORMATION)
             
         except Exception as e:
             wx.CallAfter(wx.MessageBox, f"Alignment failed: {e}", "Error", wx.OK | wx.ICON_ERROR)

--- a/src/audio.py
+++ b/src/audio.py
@@ -9,6 +9,7 @@ This module provides functionality for:
 """
 
 import os
+import json
 import torch
 import opensmile
 import gc
@@ -339,7 +340,8 @@ class AudioProcessor:
             model=self.whisper_model,
             tokenizer=self.whisper_processor.tokenizer,
             feature_extractor=self.whisper_processor.feature_extractor,
-            max_new_tokens=128,
+            # No max_new_tokens cap: a low cap (was 128) truncates long 30s chunks and
+            # breaks word-level timestamp alignment. Let Whisper use its full target window.
             chunk_length_s=30, # Standard chunk length for robustness
             batch_size=8,
             torch_dtype=self.torch_dtype,
@@ -830,16 +832,19 @@ class AudioProcessor:
             
         return "UNKNOWN"
 
-    def extract_transcripts_batch(self, audio_files, progress_callback=None):
+    def extract_transcripts_batch(self, audio_files, progress_callback=None, word_timestamps=False):
         """
         Batch process multiple audio files to generate transcripts.
-        
+
         OPTIMIZED: Loads each model once for all files instead of per-file,
         significantly reducing processing time for batches.
-        
+
         Args:
             audio_files (list): List of paths to WAV files
             progress_callback (callable, optional): Callback function for progress updates
+            word_timestamps (bool): When True, request word-level timestamps and write a
+                ``{base}_words.json`` sidecar per file so Align Features can reuse it instead
+                of re-transcribing later.
         """
         if not audio_files:
             return
@@ -890,8 +895,9 @@ class AudioProcessor:
                 audio_path = os.path.normpath(os.path.abspath(audio_file))
                 if not os.path.isfile(audio_path):
                     raise FileNotFoundError(f"Audio file not found: {audio_path}")
-                # Transcribe without loading/offloading model
-                ts_mode = True  # Use segment-level timestamps; word-level if needed for alignment
+                # Transcribe without loading/offloading model.
+                # word-level timestamps (for Align Features) when requested, else segment-level.
+                ts_mode = "word" if word_timestamps else True
                 result = self.whisper_pipe(
                     _whisper_pipeline_audio_input(audio_path),
                     return_timestamps=ts_mode,
@@ -999,6 +1005,17 @@ class AudioProcessor:
                 msg = f"{output_txt}: {e}"
                 print(f"Error saving transcript for {audio_file}: {e}")
                 save_errors.append(msg)
+
+            # When word-level timestamps were requested, write the JSON sidecar that
+            # Align Features consumes (so it won't have to re-transcribe this file).
+            if word_timestamps:
+                output_json = os.path.join(self.output_transcripts_folder, f"{base_name}_words.json")
+                try:
+                    with open(output_json, 'w', encoding='utf-8') as f:
+                        json.dump(whisper_result, f, indent=2, ensure_ascii=False)
+                    print(f"Saved word-level info: {output_json}")
+                except Exception as e:
+                    print(f"Warning: Could not save word-level JSON for {base_name}: {e}")
 
         if save_errors:
             raise RuntimeError(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,11 +1,34 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 import types
 
 import numpy as np
 import pandas as pd
+
+
+def _stub_transcription(processor, audio, monkeypatch, result):
+    """Wire a processor so extract_transcripts_batch runs without a real model/audio.
+
+    Returns the dict that captures the ``return_timestamps`` argument the pipeline saw.
+    """
+    captured = {}
+
+    monkeypatch.setattr(processor, "_load_whisper_model", lambda *a, **k: None)
+    monkeypatch.setattr(
+        audio,
+        "_whisper_pipeline_audio_input",
+        lambda path: {"array": np.zeros(4, dtype=np.float32), "sampling_rate": 16000},
+    )
+
+    def fake_pipe(audio_input, return_timestamps=None, generate_kwargs=None):
+        captured["return_timestamps"] = return_timestamps
+        return result
+
+    processor.whisper_pipe = fake_pipe
+    return captured
 
 
 def test_pcm_audio_to_mono_float32_converts_integer_stereo(import_audio):
@@ -89,3 +112,91 @@ def test_extract_audio_features_writes_timestamped_csv(monkeypatch, import_audio
     ]
     assert progress_updates[0] == 0
     assert progress_updates[-1] == 100
+
+
+def _make_processor(audio, tmp_path):
+    return audio.AudioProcessor(
+        output_audio_features_folder=str(tmp_path),
+        output_transcripts_folder=str(tmp_path),
+        status_callback=None,
+        enable_speaker_diarization=False,
+    )
+
+
+def test_extract_transcripts_batch_saves_word_json_when_requested(monkeypatch, import_audio, tmp_path):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+    word_result = {
+        "text": "hello world",
+        "chunks": [
+            {"text": "hello", "timestamp": (0.0, 0.5)},
+            {"text": "world", "timestamp": (0.5, 1.0)},
+        ],
+    }
+    captured = _stub_transcription(processor, audio, monkeypatch, word_result)
+
+    clip = tmp_path / "clip.wav"
+    clip.write_bytes(b"RIFF0000")
+
+    processor.extract_transcripts_batch([str(clip)], word_timestamps=True)
+
+    # Word-level mode was requested at call time...
+    assert captured["return_timestamps"] == "word"
+    # ...the JSON sidecar Align Features needs was written...
+    json_path = tmp_path / "clip_words.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["chunks"][0]["text"] == "hello"
+    # ...and the plain .txt transcript is still produced.
+    assert (tmp_path / "clip.txt").exists()
+
+
+def test_extract_transcripts_batch_segment_mode_writes_no_word_json(monkeypatch, import_audio, tmp_path):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+    captured = _stub_transcription(
+        processor, audio, monkeypatch, {"text": "hello world", "chunks": []}
+    )
+
+    clip = tmp_path / "clip.wav"
+    clip.write_bytes(b"RIFF0000")
+
+    processor.extract_transcripts_batch([str(clip)])  # word_timestamps defaults to False
+
+    assert captured["return_timestamps"] is True
+    assert not (tmp_path / "clip_words.json").exists()
+    assert (tmp_path / "clip.txt").exists()
+
+
+def test_align_features_maps_words_to_feature_means(import_audio, tmp_path):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+
+    features = pd.DataFrame(
+        {
+            "Timestamp_Seconds": [0.0, 0.25, 0.5, 0.75],
+            "f0": [1.0, 3.0, 5.0, 7.0],
+        }
+    )
+    feature_csv = tmp_path / "clip.csv"
+    features.to_csv(feature_csv, index=False)
+
+    words = {
+        "text": "hello world",
+        "chunks": [
+            {"text": "hello", "timestamp": (0.0, 0.5)},
+            {"text": "world", "timestamp": (0.5, 1.0)},
+        ],
+    }
+    words_json = tmp_path / "clip_words.json"
+    words_json.write_text(json.dumps(words), encoding="utf-8")
+
+    out_csv = tmp_path / "clip_aligned.csv"
+    processor.align_features(str(feature_csv), str(words_json), str(out_csv))
+
+    result = pd.read_csv(out_csv)
+    assert list(result["word"]) == ["hello", "world"]
+    # "hello" spans [0.0, 0.5] -> frames 1.0, 3.0, 5.0 -> mean 3.0
+    assert result.loc[0, "f0"] == 3.0
+    # "world" spans [0.5, 1.0] -> frames 5.0, 7.0 -> mean 6.0
+    assert result.loc[1, "f0"] == 6.0


### PR DESCRIPTION
## Summary

Closes #22

- **Feature:** Adds **"Save word-level timestamps (for Align Features)"** checkbox on Extract Transcripts. When checked, batch transcription requests `return_timestamps="word"` and writes `transcripts/{name}_words.json` sidecars that Align Features reuses instead of re-transcribing every file.
- **Bug fix:** Removes Whisper `max_new_tokens=128` cap that truncated long chunks and broke word-level timestamp alignment.
- **UX:** When Align Features cannot build any pairs, the warning popup lists per-file reasons (missing JSON, feature CSV not produced, transcript failure) instead of a silent "No valid pairs" message after hours of work.
- **Release:** Bumps `pyproject.toml` to **1.0.1** so the upstream merge can publish `v1.0.1` (v1.0.0 already exists).

## Workflow (for large batches, e.g. ~200 files)

1. Select folder → check **Save word-level timestamps (for Align Features)**
2. **Extract Transcripts** → `transcripts/{name}.txt` + `transcripts/{name}_words.json`
3. **Extract Audio Features** → `audio_features/{name}.csv`
4. **Align Features** → reuses existing JSON (no re-transcribe); writes `audio_features/{name}_aligned.csv` with `word, start_time, end_time, duration` + ComParE columns

## Test plan

- [x] `pytest tests/test_audio.py` — 9 passed (word JSON sidecar, segment mode, align mapping)
- [x] Manual end-to-end on AMI samples: batch (3 files) + single (1 file); word JSON chunks verified; align did not re-transcribe; diarization labels on single; error popup surfaces decode failure on invalid wav
- [x] Fork packaging: `v1.0.1-test1` — [CI passed](https://github.com/Muneeb-ii/MultiSOCIAL_toolbox/actions/runs/27636765431) (macOS + Windows, Standard + Complete)