### PR TITLE
UI redesign + Align Features fix (v1.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Build Releases
 
+env:
+  UPSTREAM_REPOSITORY: Tahiya31/MultiSOCIAL_toolbox
+
 on:
   workflow_dispatch:
   push:
@@ -13,6 +16,7 @@ permissions:
 
 jobs:
   prepare:
+    # env context is unavailable in job-level if; keep in sync with env.UPSTREAM_REPOSITORY above.
     if: ${{ !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository == 'Tahiya31/MultiSOCIAL_toolbox') }}
     runs-on: ubuntu-latest
     outputs:
@@ -26,6 +30,8 @@ jobs:
 
       - name: Derive release metadata
         id: meta
+        env:
+          UPSTREAM_REPOSITORY: ${{ env.UPSTREAM_REPOSITORY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -49,7 +55,7 @@ jobs:
             TRIGGER_KIND="tag"
           elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
             TRIGGER_KIND="main"
-            if [[ "${GITHUB_REPOSITORY}" == "Tahiya31/MultiSOCIAL_toolbox" ]]; then
+            if [[ "${GITHUB_REPOSITORY}" == "${UPSTREAM_REPOSITORY}" ]]; then
               SHOULD_PUBLISH_RELEASE="true"
             fi
           fi
@@ -105,6 +111,7 @@ jobs:
             });
 
   build:
+    # env context is unavailable in job-level if; keep in sync with env.UPSTREAM_REPOSITORY above.
     if: ${{ !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository == 'Tahiya31/MultiSOCIAL_toolbox') }}
     needs: prepare
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,11 @@ venv/
 
 # Pretrained models
 /pretrained_models/
+
+# Agent cofig
+.cursor/
+CONTEXT.md
+
+# Testing Workflows
+/audio-test
+/pose-test

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,197 @@
+# MultiSOCIAL Toolbox — UI Design System
+
+Canonical reference for GUI work in this project. Implementation lives in `src/gui_utils.py` (tokens) and `src/ui_components.py` (components).
+
+## Palette
+
+The app uses a refined **teal → forest green** gradient background with semi-transparent cards and owner-drawn controls.
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `COLOR_BG_GRADIENT_START` | `#004D40` | Gradient top (deep teal) |
+| `COLOR_BG_GRADIENT_END` | `#1B5E20` | Gradient bottom (deep forest) |
+| `COLOR_BG_GLOW` | `(76, 175, 80, 35)` | Radial ambient highlight at top |
+| `COLOR_SURFACE` | `(22, 32, 30, 215)` | Section card fill |
+| `COLOR_SURFACE_ELEVATED` | `(28, 42, 38, 230)` | Elevated cards (footer, data) |
+| `COLOR_INPUT_BG` | `(14, 22, 20)` | Native SpinCtrl / DirPicker on cards |
+| `COLOR_GLASS_BORDER` / `COLOR_SURFACE_BORDER` | `(255, 255, 255, 28)` | Card borders |
+| `COLOR_BORDER_HIGHLIGHT` | `(255, 255, 255, 55)` | Top-edge card highlight |
+| `COLOR_PRIMARY` | `#4CAF50` | Primary action buttons |
+| `COLOR_PRIMARY_HOVER` | `#66BB6A` | Primary hover |
+| `COLOR_PRIMARY_PRESSED` | `#388E3C` | Primary pressed |
+| `COLOR_SECONDARY` | `(255, 255, 255, 18)` | Ghost / outline buttons |
+| `COLOR_SECONDARY_BORDER` | `(255, 255, 255, 45)` | Secondary outline |
+| `COLOR_DANGER` | `#E53935` | Cancel button |
+| `COLOR_TAB_TRACK` / `COLOR_TAB_ACTIVE` | dark inset / light pill | Segmented mode control |
+| `COLOR_ACCENT_GREEN` | `#A5D6A7` | Logo ring, tab hover |
+| `COLOR_PROGRESS_FILL` | `(102, 187, 106)` | Progress bar fill (gradient) |
+| `COLOR_PROGRESS_TRACK` | `(0, 0, 0, 90)` | Progress bar track |
+| `COLOR_TEXT_WHITE` | `#FFFFFF` | Labels on gradient / cards |
+| `COLOR_TEXT_MUTED` | `#90A4AE` | Overlines, subtitles, de-emphasized |
+| `COLOR_DISABLED` | `(120, 144, 156, 180)` | Disabled controls |
+| `COLOR_TEXT_ON_DARK` | `#FFFFFF` | Button labels |
+| `COLOR_TOOLTIP_BG` / `COLOR_TOOLTIP_FG` | `#1E1E1E` / `#F5F5F5` | Tooltips |
+
+Legacy aliases (`COLOR_PROGRESS_GREEN`, `COLOR_TEXT_BLACK`, `COLOR_INFO_ICON_BG`) remain for backward compatibility.
+
+## Typography
+
+Use `Theme.get_font(size, bold=False)` everywhere.
+
+A deliberate ramp (no two adjacent roles within 1 pt) keeps hierarchy legible.
+
+| Token | Size (pt) | Usage |
+|-------|-----------|-------|
+| `FONT_DISPLAY` | 32 | App name ("MultiSOCIAL Toolbox") |
+| `FONT_TITLE` | 17 | Section / screen titles |
+| `FONT_BUTTON` | 16 | Action buttons |
+| `FONT_HEADING` | 15 | Primary settings labels |
+| `FONT_BODY` | 14 | Labels, spin controls, status |
+| `FONT_SUBTITLE` | 13 | Header subtitle |
+| `FONT_CAPTION` | 12 | Secondary / diarization status sublabels |
+| `FONT_OVERLINE` | 11 | Uppercase card eyebrow headings |
+
+**Platform fonts:** Segoe UI (Windows), SF Pro Text (macOS), Swiss (Linux).
+
+**Resize scaling is capped at 1.25×** (`on_resize`) so typography stays consistent
+across window sizes — large windows are filled by the responsive layout, not by
+ballooning fonts (which also risked overflowing fixed-width cards).
+
+Bold: headings, status line, card titles, tab labels.
+
+## Spacing and radius
+
+| Token | px | Usage |
+|-------|-----|-------|
+| `SPACE_XS` | 4 | Tight gaps |
+| `SPACE_SM` | 8 | Inline control spacing |
+| `SPACE_MD` | 12 | Card padding, button margins |
+| `SPACE_LG` | 16 | Section gaps |
+| `SPACE_XL` | 24 | Section margins |
+| `SPACE_XXL` | 32 | Header breathing room |
+
+| Token | px | Usage |
+|-------|-----|-------|
+| `RADIUS_BUTTON` | 10 | FlatButton corners |
+| `RADIUS_CARD` | 14 | SectionCard |
+| `RADIUS_TAB` | 12 | Segmented mode control |
+
+Use `FromDIP()` for radii and min heights so scaling respects display density.
+
+## Layout structure
+
+```
+GradientPanel (scrollable root)
+├── Header — logo + title + subtitle (horizontal, full width)
+├── ToggleTabBar — segmented Video | Audio          ┐
+├── SectionCard "DATA FOLDER" — caption + DirPickerCtrl │ centered content column,
+├── videoPanel / audioPanel (chrome-less grouping)      │ all blocks share one width
+│   ├── SectionCard "SETTINGS"                           │ (see Responsive scaling)
+│   └── SectionCard "ACTIONS"                            │
+└── SectionCard "STATUS"                              ┘
+    ├── statusLabel · CustomGauge (progress) · cancelBtn (danger, hidden when idle)
+```
+
+**Mode panels** are toggled (not `wx.Notebook`). Only one of `videoPanel` / `audioPanel` is visible.
+
+**Responsive panel layout.** Inside each mode panel, `SETTINGS` and `ACTIONS`
+stack vertically on narrow windows and sit **side-by-side** at/above the
+breakpoint (`width ≥ FromDIP(860)`), where the content column also widens to
+~90% of the frame. This removes the large side margins / vertical scrolling on
+desktop-sized windows. Orientation is rebuilt (fresh `BoxSizer`, not
+`SetOrientation`) only when the mode flips — see `_apply_panel_orientation`.
+
+**Content alignment.** The **header bar**, `ToggleTabBar`, `DATA FOLDER`, the mode
+panels, and `STATUS` are all sized to the same width and centered (one shared
+content column), so their left/right edges line up at every window size. The
+header logo+title is wrapped in a chrome-less `GlassPanel` for this reason — do
+not add it full-width. All centered blocks use `wx.ALIGN_CENTER_HORIZONTAL` (never
+`wx.EXPAND`, which left-aligns within the margins and breaks the column).
+
+**Settings rows** use a 2-column `FlexGridSizer` (label | control, growable label
+column) so numeric inputs share one aligned baseline; toggles are full-width and
+left-aligned. Avoid `wx.ALIGN_CENTER` for settings — it produces ragged edges.
+
+**Action hierarchy.** Exactly one `primary` (filled green) action per panel — the
+core step (video: *Extract Pose Features*; audio: *Extract Audio Features*).
+Prerequisite, QA, and optional steps (Convert, Embed, Verify, Transcripts, Align)
+use `secondary` (ghost outline). One filled CTA + outline siblings = clear path.
+
+**Native controls kept:** `wx.SpinCtrl`, `wx.DirPickerCtrl` — placed inside `SectionCard` on solid surfaces.
+
+## Components
+
+### FlatButton
+
+Owner-drawn rounded button with drop shadow and top highlight. Variants: `primary`, `secondary` (ghost outline), `danger`.
+
+| State | Behavior |
+|-------|----------|
+| Normal | Base variant color |
+| Hover | `*_HOVER` token |
+| Pressed | `*_PRESSED` token |
+| Disabled | `COLOR_DISABLED`, no click |
+
+Emits `wx.EVT_BUTTON`. API: `SetLabel`, `GetLabel`, `Enable`, `SetFont`, `SetMinSize`.
+
+### ToggleTabBar
+
+Segmented pill control (Video | Audio). Active segment uses elevated fill; hover highlights inactive label. `set_selected('video'|'audio')`, `EnableTabs(bool)`. Font scaling via `video_tab` / `audio_tab` proxies.
+
+### CustomCheckBox
+
+Owner-drawn checkbox + label. `GetValue` / `SetValue`, `SetLabel`, emits `wx.EVT_CHECKBOX`.
+
+### SectionCard
+
+`GlassPanel` subclass with uppercase overline heading, divider, and `SPACE_LG` padding. Uses `COLOR_SURFACE_ELEVATED`. `content_sizer` for children.
+
+Native inputs on cards: call `gui_utils.style_native_input()` for `SpinCtrl` / `DirPickerCtrl`.
+
+### CustomGauge
+
+Rounded progress track with gradient fill and top shine. Default height 32 DIP.
+
+### TooltipButton
+
+Horizontal row: expanding `FlatButton` + `InfoIcon` (unchanged tooltip behavior).
+
+### ResponsiveText
+
+Entry point: `gui_utils.create_transparent_text()` — `TransparentStaticText` on Windows, `wx.StaticText` on macOS.
+
+## Cross-platform rules
+
+1. **Owner-draw interactive controls** — buttons and checkboxes must not use native `wx.Button` / `wx.CheckBox` on glass backgrounds.
+2. **Never rely on native transparency** for interactive widgets; use `BG_STYLE_PAINT` + `GraphicsContext`.
+3. **Fill the control background on Windows.** `BG_STYLE_PAINT` gives no real transparency on Windows, so an owner-drawn `wx.Window`'s rounded corners / shadow band would show an uninitialised background. Every owner-drawn control calls `_fill_windows_background(self, dc)` first (no-op on macOS), which fills with `gui_utils.composited_background_colour()` — the gradient sampled at the control's position, composited with any chrome-painting `GlassPanel` ancestor. This is why `FlatButton` / `CustomCheckBox` / `ToggleTabBar` / `CustomGauge` look identical on both platforms. **Keep effects (shadow, shine, glow, gradients) — they render consistently via GDI+; it's the *background* that diverges.**
+4. **Single font-scaling registry** — register `(widget, base_size, bold)` at creation; scale in one `on_resize` loop (max 2× baseline). The loop is per-widget defensive (proxies without `IsShown` are allowed; one failure never aborts the pass).
+5. **Windows gradient under cards** — keep `GlassPanel._paint_gradient_background_windows`; owner-drawn children sit on top.
+6. **Adding a new control** — if it is clickable, owner-draw it **and call `_fill_windows_background` at the top of its paint**; if native (picker/spin), put it in a `SectionCard` + `style_native_input`; register fonts in `_scalable_widgets`.
+
+## Cancel UX (#17)
+
+| Phase | UI |
+|-------|-----|
+| Idle | Cancel hidden and disabled |
+| Job started | `_begin_process()` — disable actions, tabs, folder picker; show Cancel |
+| User clicks Cancel | Status: "Cancelling…"; Cancel disabled (no double-click) |
+| Job ends (cancelled) | Status: "Processing cancelled."; no success dialog |
+| Job ends (success) | Success `MessageBox`; status cleared on next action |
+
+**Cancel granularity:**
+
+- **Pose extract / embed:** cooperative check each frame (`cancel_check` in `pose.py` loops).
+- **All other batch jobs:** stop at next file boundary (convert, verify, audio features, transcripts, align prep).
+
+Diarization pip install is out of scope for Cancel.
+
+## Responsive scaling
+
+- Baseline size captured at first layout (`_baseline_size`).
+- Scale factor: `min(width_ratio, height_ratio, 2.0)`, never below 1.0.
+- **Content-column width** (`_update_panel_sizes`):
+  - Two-column (`width ≥ FromDIP(860)`): `min(90% of frame, FromDIP(1180))`, floor `FromDIP(720)`.
+  - Single-column: `min(70% of frame, FromDIP(640))`, floor `FromDIP(360)`.
+- Tabs, folder card, mode panels, and status footer all use this width (centered).
+- Progress bar height fixed at `FromDIP(34)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multisocial-toolbox"
-version = "1.0.0"
+version = "1.0.1"
 description = "Desktop toolbox for multimodal interaction analysis across video and audio."
 readme = "README.md"
 requires-python = ">=3.10,<3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multisocial-toolbox"
-version = "1.0.1"
+version = "1.1.0"
 description = "Desktop toolbox for multimodal interaction analysis across video and audio."
 readme = "README.md"
 requires-python = ">=3.10,<3.11"

--- a/run_app.bat
+++ b/run_app.bat
@@ -122,12 +122,25 @@ if "%NEEDS_INSTALL%"=="1" (
     )
 
     pushd "%SCRIPT_DIR%"
+    python -c "import shutil, site; from pathlib import Path; sp=Path(site.getsitepackages()[0]); removed=[]; \
+[removed.append(p.name) or (shutil.rmtree(p, ignore_errors=True) if p.is_dir() else p.unlink(missing_ok=True)) for pat in ('multisocial_toolbox-*.dist-info','__editable__.multisocial_toolbox-*.pth') for p in sorted(sp.glob(pat))]; \
+print('Cleared stale multisocial-toolbox install metadata:', ', '.join(removed)) if removed else None"
     if /I "%MULTISOCIAL_INSTALL_PROFILE%"=="complete" (
         python -m pip install -e ".[complete]"
     ) else (
         python -m pip install -e .
     )
-    if %errorlevel% neq 0 (
+    if !errorlevel! neq 0 (
+        echo Install failed; clearing stale metadata and retrying with --ignore-installed...
+        python -c "import shutil, site; from pathlib import Path; sp=Path(site.getsitepackages()[0]); \
+[(shutil.rmtree(p, ignore_errors=True) if p.is_dir() else p.unlink(missing_ok=True)) for pat in ('multisocial_toolbox-*.dist-info','__editable__.multisocial_toolbox-*.pth') for p in sorted(sp.glob(pat))]"
+        if /I "%MULTISOCIAL_INSTALL_PROFILE%"=="complete" (
+            python -m pip install --ignore-installed -e ".[complete]"
+        ) else (
+            python -m pip install --ignore-installed -e .
+        )
+    )
+    if !errorlevel! neq 0 (
         echo ERROR: Failed to install toolbox dependencies
         echo Please check your internet connection and try again
         popd

--- a/run_app.sh
+++ b/run_app.sh
@@ -69,6 +69,26 @@ fi
 echo "Activating virtual environment"
 source "$VENV_DIR/bin/activate"
 
+scrub_multisocial_editable_install() {
+    python - <<'PY'
+import shutil
+import site
+from pathlib import Path
+
+sp = Path(site.getsitepackages()[0])
+removed = []
+for pattern in ("multisocial_toolbox-*.dist-info", "__editable__.multisocial_toolbox-*.pth"):
+    for path in sorted(sp.glob(pattern)):
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)
+        removed.append(path.name)
+if removed:
+    print("Cleared stale multisocial-toolbox install metadata:", ", ".join(removed))
+PY
+}
+
 CURRENT_STAMP="$(python -c "from pathlib import Path; import hashlib; print('${INSTALL_PROFILE}|${DESIRED_PYTHON}|' + hashlib.sha256(Path(r'''$SCRIPT_DIR/pyproject.toml''').read_bytes()).hexdigest())")"
 NEEDS_INSTALL=1
 if [ -f "$INSTALL_STAMP_FILE" ]; then
@@ -93,16 +113,23 @@ if [ "$NEEDS_INSTALL" -eq 1 ]; then
     fi
 
     pushd "$SCRIPT_DIR" >/dev/null
+    scrub_multisocial_editable_install
     if [ "$INSTALL_PROFILE" = "complete" ]; then
         INSTALL_CMD=(python -m pip install -e ".[complete]")
+        RETRY_CMD=(python -m pip install --ignore-installed -e ".[complete]")
     else
         INSTALL_CMD=(python -m pip install -e .)
+        RETRY_CMD=(python -m pip install --ignore-installed -e .)
     fi
     if ! "${INSTALL_CMD[@]}"; then
-        echo "ERROR: Failed to install toolbox dependencies"
-        echo "Please check your internet connection and try again"
-        popd >/dev/null
-        exit 1
+        echo "Install failed; clearing stale metadata and retrying with --ignore-installed..."
+        scrub_multisocial_editable_install
+        if ! "${RETRY_CMD[@]}"; then
+            echo "ERROR: Failed to install toolbox dependencies"
+            echo "Please check your internet connection and try again"
+            popd >/dev/null
+            exit 1
+        fi
     fi
     popd >/dev/null
     printf '%s\n' "$CURRENT_STAMP" > "$INSTALL_STAMP_FILE"

--- a/src/app.py
+++ b/src/app.py
@@ -25,7 +25,17 @@ load_dotenv()
 import gui_utils
 import runtime_services
 from gui_utils import Theme
-from ui_components import GradientPanel, GlassPanel, ElevatedLogoPanel, TooltipButton, CustomGauge
+from ui_components import (
+    GradientPanel,
+    GlassPanel,
+    ElevatedLogoPanel,
+    TooltipButton,
+    CustomGauge,
+    FlatButton,
+    ToggleTabBar,
+    CustomCheckBox,
+    SectionCard,
+)
 
 _PoseProcessorCls = None
 
@@ -67,12 +77,79 @@ class VideoToWavConverter(wx.Frame):
         # Track if a background process is running to prevent UI resets during tab switches
         self._process_running = False
         self._diarization_install_running = False
+        self._cancel_event = threading.Event()
+        self._scalable_widgets = []  # (widget, base_size, bold)
+        self._panels_horizontal = None  # tri-state: None = not yet laid out
         # File extensions constants
         self.VIDEO_EXTENSIONS = (".mp4", ".avi", ".mov", ".mkv", ".m4v")
         self.AUDIO_EXTENSIONS = (".wav", ".wave", ".aiff", ".aif", ".aifc", ".flac", ".caf", ".au", ".snd")
 
     def _format_supported_extensions(self, extensions):
         return ", ".join(extensions)
+
+    def _register_scalable(self, widget, base_size, bold=False):
+        if widget is not None:
+            self._scalable_widgets.append((widget, base_size, bold))
+
+    def _begin_process(self):
+        self._cancel_event.clear()
+        self._process_running = True
+        self._set_process_controls_enabled(False)
+        if hasattr(self, "cancelBtn") and self.cancelBtn:
+            self.cancelBtn.Show()
+            self.cancelBtn.Enable(True)
+        self._relayout_main()
+
+    def _end_process(self, cancelled=False):
+        self._process_running = False
+        if hasattr(self, "cancelBtn") and self.cancelBtn:
+            self.cancelBtn.Hide()
+            self.cancelBtn.Enable(False)
+        self.update_progress(0)
+        self._set_process_controls_enabled(True)
+        if cancelled:
+            self.set_status_message("Processing cancelled.")
+        else:
+            self._refresh_idle_hint()
+        self.update_buttons_enabled()
+        self._relayout_main()
+
+    def _relayout_main(self):
+        """Reflow the scrolled main panel so showing/hiding the Cancel button
+        actually reclaims its space (frame-level Layout() alone won't)."""
+        if hasattr(self, "mainPanel") and self.mainPanel:
+            self.mainPanel.Layout()
+            try:
+                self.mainPanel.FitInside()
+            except Exception:
+                pass
+        self.Layout()
+
+    def _set_process_controls_enabled(self, enabled):
+        if hasattr(self, "modeTabs") and self.modeTabs:
+            self.modeTabs.EnableTabs(enabled)
+        if hasattr(self, "folderPicker") and self.folderPicker:
+            self.folderPicker.Enable(enabled)
+        if not enabled:
+            for btn in [
+                getattr(self, "convertBtn", None),
+                getattr(self, "extractFeaturesBtn", None),
+                getattr(self, "embedFeaturesBtn", None),
+                getattr(self, "verifyBtn", None),
+                getattr(self, "extractAudioFeaturesBtn", None),
+                getattr(self, "extractTranscriptsBtn", None),
+                getattr(self, "alignFeaturesBtn", None),
+            ]:
+                if btn:
+                    btn.Enable(False)
+
+    def on_cancel(self, event):
+        if not self._process_running:
+            return
+        self._cancel_event.set()
+        self.set_status_message("Cancelling...")
+        if hasattr(self, "cancelBtn") and self.cancelBtn:
+            self.cancelBtn.Enable(False)
         
     def _init_ui(self):
         pnl = GradientPanel(self)
@@ -90,18 +167,18 @@ class VideoToWavConverter(wx.Frame):
         # Folder Picker
         self._create_folder_picker(pnl, vbox)
         
-        # Panels for Video and Audio options
-        self.videoPanel = GlassPanel(pnl)
-        self.audioPanel = GlassPanel(pnl)
+        # Panels for Video and Audio options (invisible grouping — cards provide chrome)
+        self.videoPanel = GlassPanel(pnl, chrome=False)
+        self.audioPanel = GlassPanel(pnl, chrome=False)
         
         self._create_video_panel()
         self._create_audio_panel()
         
-        # Assemble panels
-        vbox.AddSpacer(10)
-        vbox.Add(self.videoPanel, proportion=0, flag=wx.ALIGN_CENTER|wx.LEFT|wx.RIGHT, border=12)
-        vbox.Add(self.audioPanel, proportion=0, flag=wx.ALIGN_CENTER|wx.LEFT|wx.RIGHT, border=12)
-        vbox.AddStretchSpacer(1)
+        # Assemble panels (centered to a content column; width set in _update_panel_sizes)
+        vbox.AddSpacer(self.FromDIP(Theme.SPACE_SM))
+        vbox.Add(self.videoPanel, proportion=0, flag=wx.ALIGN_CENTER_HORIZONTAL | wx.TOP, border=Theme.SPACE_SM)
+        vbox.Add(self.audioPanel, proportion=0, flag=wx.ALIGN_CENTER_HORIZONTAL | wx.TOP, border=Theme.SPACE_SM)
+        vbox.AddSpacer(self.FromDIP(Theme.SPACE_LG))
         
         # Status and Progress
         self._create_status_and_progress(pnl, vbox)
@@ -116,258 +193,289 @@ class VideoToWavConverter(wx.Frame):
 
     def _create_header(self, pnl, vbox):
         new_width, new_height = wx.GetDisplaySize()
-        logo_size = min(int(new_height * 0.06), 120)
-        
-        top_box = wx.BoxSizer(wx.HORIZONTAL)
-        
-        # Logo
+        logo_size = min(int(new_height * 0.055), 96)
+
+        # Header lives in a centered, width-clamped container (like the cards) so the
+        # logo/title left edge lines up with the content column at every window size.
+        self.headerBar = GlassPanel(pnl, chrome=False)
+        header_row = wx.BoxSizer(wx.HORIZONTAL)
+
         logo_path = runtime_services.resource_path("assets", "MultiSOCIAL_logo.png")
         logo_image = wx.Image(logo_path, wx.BITMAP_TYPE_ANY)
         logo_image = logo_image.Scale(logo_size, logo_size, wx.IMAGE_QUALITY_HIGH)
         logo_bmp = wx.Bitmap(logo_image)
-        
-        elevated_logo = ElevatedLogoPanel(pnl, logo_bmp)
-        elevated_logo.SetMinSize((logo_size + 20, logo_size + 20))
-        
-        top_box.AddStretchSpacer(1)
-        top_box.Add(elevated_logo, flag=wx.ALIGN_CENTER | wx.ALL, border=15)
-        top_box.AddStretchSpacer(1)
 
-        vbox.Add(top_box, flag=wx.EXPAND | wx.TOP | wx.BOTTOM, border=10)
-        
-        # Title
-        self.title = gui_utils.create_transparent_text(pnl, label="Welcome to", style=wx.ALIGN_CENTER)
-        self.title.SetFont(Theme.get_font(20))
-        self.title.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        vbox.Add(self.title, flag=wx.ALIGN_CENTER | wx.BOTTOM, border=10)
+        elevated_logo = ElevatedLogoPanel(self.headerBar, logo_bmp)
+        elevated_logo.SetMinSize((logo_size + 16, logo_size + 16))
+        header_row.Add(elevated_logo, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, border=Theme.SPACE_LG)
 
-        # Logo Label
-        self.logoLabel = gui_utils.create_transparent_text(pnl, label="MultiSOCIAL Toolbox", style=wx.ALIGN_CENTER)
-        self.logoLabel.SetFont(Theme.get_font(24, bold=True))
-        self.logoLabel.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
+        title_col = wx.BoxSizer(wx.VERTICAL)
+        self.logoLabel = gui_utils.create_transparent_text(self.headerBar, label="MultiSOCIAL Toolbox", style=wx.ALIGN_LEFT)
+        self.logoLabel.SetFont(Theme.get_font(Theme.FONT_DISPLAY, bold=True))
+        self.logoLabel.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+        self._register_scalable(self.logoLabel, Theme.FONT_DISPLAY, bold=True)
+        title_col.Add(self.logoLabel, flag=wx.ALIGN_LEFT)
 
-        vbox.Add(self.logoLabel, flag=wx.ALIGN_CENTER|wx.TOP, border=5)
+        self.subtitleLabel = gui_utils.create_transparent_text(
+            self.headerBar, label="Pose · Audio · Alignment", style=wx.ALIGN_LEFT
+        )
+        self.subtitleLabel.SetFont(Theme.get_font(Theme.FONT_SUBTITLE))
+        self.subtitleLabel.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_MUTED))
+        self._register_scalable(self.subtitleLabel, Theme.FONT_SUBTITLE)
+        title_col.Add(self.subtitleLabel, flag=wx.ALIGN_LEFT | wx.TOP, border=Theme.SPACE_XS)
+
+        header_row.Add(title_col, proportion=1, flag=wx.ALIGN_CENTER_VERTICAL)
+        self.headerBar.SetSizer(header_row)
+        vbox.Add(self.headerBar, flag=wx.ALIGN_CENTER_HORIZONTAL | wx.TOP, border=Theme.SPACE_XL)
 
     def _create_mode_selection(self, pnl, vbox):
-        mode_box = wx.BoxSizer(wx.HORIZONTAL)
-        self.videoModeBtn = wx.Button(pnl, label="Video Options")
-        self.audioModeBtn = wx.Button(pnl, label="Audio Options")
-        
-        mode_btn_font = Theme.get_font(11, bold=True)
-        self.videoModeBtn.SetFont(mode_btn_font)
-        self.audioModeBtn.SetFont(mode_btn_font)
-        
-        self.videoModeBtn.Bind(wx.EVT_BUTTON, lambda evt: self.switch_mode('video'))
-        self.audioModeBtn.Bind(wx.EVT_BUTTON, lambda evt: self.switch_mode('audio'))
-        
-        mode_box.AddStretchSpacer(1)
-        mode_box.Add(self.videoModeBtn, flag=wx.ALL, border=5)
-        mode_box.Add(self.audioModeBtn, flag=wx.ALL, border=5)
-        mode_box.AddStretchSpacer(1)
-        vbox.Add(mode_box, flag=wx.EXPAND|wx.TOP|wx.BOTTOM, border=10)
-        
-        # Underlines
-        self._video_underline = wx.Panel(pnl, size=(-1, self.FromDIP(3)))
-        self._video_underline.SetBackgroundColour(Theme.COLOR_ACCENT_GREEN)
-        self._audio_underline = wx.Panel(pnl, size=(-1, self.FromDIP(3)))
-        self._audio_underline.SetBackgroundColour(Theme.COLOR_ACCENT_GREEN)
-        
-        mode_box.Insert(2, self._audio_underline, flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=5)
-        mode_box.Insert(1, self._video_underline, flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=5)
-        
-        self._video_underline.Hide()
-        self._audio_underline.Hide()
+        self.modeTabs = ToggleTabBar(pnl)
+        self.modeTabs.set_on_change(self.switch_mode)
+        self._register_scalable(self.modeTabs.video_tab, Theme.FONT_BODY, bold=True)
+        self._register_scalable(self.modeTabs.audio_tab, Theme.FONT_BODY, bold=True)
+        vbox.Add(self.modeTabs, flag=wx.ALIGN_CENTER_HORIZONTAL | wx.TOP, border=Theme.SPACE_LG)
 
     def _create_folder_picker(self, pnl, vbox):
-        self.folderCaption = gui_utils.create_transparent_text(pnl, label="Select a folder containing VIDEO files", style=wx.ALIGN_CENTER)
-        self.folderCaption.SetFont(Theme.get_font(13, bold=True))
-        self.folderCaption.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        vbox.Add(self.folderCaption, flag=wx.ALIGN_CENTER|wx.LEFT|wx.RIGHT|wx.TOP, border=8)
-        
-        self.folderPicker = wx.DirPickerCtrl(pnl, message="Select a folder containing media files")
+        self.folderCard = SectionCard(pnl, heading="Data folder")
+        folder_card = self.folderCard
+        content = folder_card.content_sizer
+
+        self.folderCaption = gui_utils.create_transparent_text(
+            folder_card,
+            label="Select a folder containing VIDEO files",
+            style=wx.ALIGN_LEFT,
+        )
+        self.folderCaption.SetFont(Theme.get_font(Theme.FONT_BODY, bold=True))
+        self.folderCaption.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+        self._register_scalable(self.folderCaption, Theme.FONT_BODY, bold=True)
+        content.Add(self.folderCaption, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
+        self.folderPicker = wx.DirPickerCtrl(
+            folder_card, message="Select a folder containing media files"
+        )
         self.folderPicker.Bind(wx.EVT_DIRPICKER_CHANGED, self.on_folder_changed)
-        vbox.Add(self.folderPicker, flag=wx.ALIGN_CENTER | wx.ALL, border=10, proportion=0)
+        gui_utils.style_native_input(self.folderPicker)
+        content.Add(self.folderPicker, flag=wx.EXPAND)
+
+        vbox.Add(folder_card, flag=wx.ALIGN_CENTER_HORIZONTAL | wx.TOP, border=Theme.SPACE_LG)
 
     def _create_video_panel(self):
         video_sizer = wx.BoxSizer(wx.VERTICAL)
-        
-        # Placeholder
-        self.placeholderVideoLabel = gui_utils.create_transparent_text(self.videoPanel, label="If you have a video file:")
-        self.placeholderVideoLabel.SetFont(Theme.get_font(20))
-        video_sizer.AddSpacer(10)
-        video_sizer.Add(self.placeholderVideoLabel, flag=wx.ALIGN_CENTER|wx.ALL, border=10)
-        
-        # Multi-person checkbox
-        self.multiPersonCheckbox = wx.CheckBox(self.videoPanel, label="Enable Multi-Person Pose")
-        self.multiPersonCheckbox.SetFont(Theme.get_font(14))
-        self.multiPersonCheckbox.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        gui_utils.style_checkbox_for_glass(self.multiPersonCheckbox)
-        video_sizer.Add(self.multiPersonCheckbox, flag=wx.ALIGN_CENTER|wx.ALL, border=10)
-        
-        # Downsampling controls
-        ds_box = wx.BoxSizer(wx.HORIZONTAL)
-        ds_label = gui_utils.create_transparent_text(self.videoPanel, label="Process every k-th frame:")
-        ds_label.SetFont(Theme.get_font(12))
+
+        settings_card = SectionCard(self.videoPanel, heading="Settings")
+        settings = settings_card.content_sizer
+
+        # Toggles: stacked, left-aligned (full-width so the hover row reads cleanly)
+        self.multiPersonCheckbox = CustomCheckBox(settings_card, label="Enable Multi-Person Pose")
+        self.multiPersonCheckbox.SetFont(Theme.get_font(Theme.FONT_HEADING))
+        self.multiPersonCheckbox.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+        self._register_scalable(self.multiPersonCheckbox, Theme.FONT_HEADING)
+        settings.Add(self.multiPersonCheckbox, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
+        self.downscaleCheckbox = CustomCheckBox(settings_card, label="Downscale to 720p for processing")
+        self.downscaleCheckbox.SetFont(Theme.get_font(Theme.FONT_BODY))
+        self.downscaleCheckbox.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+        self._register_scalable(self.downscaleCheckbox, Theme.FONT_BODY)
+        settings.Add(self.downscaleCheckbox, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_MD)
+
+        # Labeled numeric inputs: 2-col grid (label | control) on a shared baseline.
+        # Growable label column pushes the spin controls into one aligned right column.
+        grid = wx.FlexGridSizer(rows=2, cols=2, vgap=self.FromDIP(Theme.SPACE_SM), hgap=self.FromDIP(Theme.SPACE_MD))
+        grid.AddGrowableCol(0, 1)
+
+        ds_label = gui_utils.create_transparent_text(settings_card, label="Process every k-th frame:")
+        ds_label.SetFont(Theme.get_font(Theme.FONT_BODY))
         ds_label.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        ds_box.Add(ds_label, flag=wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, border=8)
-        
-        self.frameStrideInput = wx.SpinCtrl(self.videoPanel, value="1", min=1, max=10)
-        self.frameStrideInput.SetFont(Theme.get_font(12))
-        ds_box.Add(self.frameStrideInput, flag=wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, border=20)
-        
-        self.downscaleCheckbox = wx.CheckBox(self.videoPanel, label="Downscale to 720p for processing")
-        self.downscaleCheckbox.SetFont(Theme.get_font(12))
-        self.downscaleCheckbox.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        gui_utils.style_checkbox_for_glass(self.downscaleCheckbox)
-        ds_box.Add(self.downscaleCheckbox, flag=wx.ALIGN_CENTER_VERTICAL)
-        video_sizer.Add(ds_box, flag=wx.ALIGN_CENTER|wx.ALL, border=10)
-        
-        # Frame threshold
-        frame_threshold_box = wx.BoxSizer(wx.HORIZONTAL)
-        frame_threshold_label = gui_utils.create_transparent_text(self.videoPanel, label="Frame Threshold for Bounding Box Recalibration:")
-        frame_threshold_label.SetFont(Theme.get_font(12))
+        self._register_scalable(ds_label, Theme.FONT_BODY)
+        grid.Add(ds_label, flag=wx.ALIGN_CENTER_VERTICAL)
+
+        self.frameStrideInput = wx.SpinCtrl(settings_card, value="1", min=1, max=10)
+        self.frameStrideInput.SetFont(Theme.get_font(Theme.FONT_BODY))
+        gui_utils.style_native_input(self.frameStrideInput)
+        self._register_scalable(self.frameStrideInput, Theme.FONT_BODY)
+        grid.Add(self.frameStrideInput, flag=wx.ALIGN_CENTER_VERTICAL)
+
+        frame_threshold_label = gui_utils.create_transparent_text(
+            settings_card, label="Frame Threshold for Bounding Box Recalibration:"
+        )
+        frame_threshold_label.SetFont(Theme.get_font(Theme.FONT_BODY))
         frame_threshold_label.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        frame_threshold_box.Add(frame_threshold_label, flag=wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, border=10)
-        
-        self.frameThresholdInput = wx.SpinCtrl(self.videoPanel, value="10", min=1, max=100)
-        self.frameThresholdInput.SetFont(Theme.get_font(12))
-        frame_threshold_box.Add(self.frameThresholdInput, flag=wx.ALIGN_CENTER_VERTICAL)
-        video_sizer.Add(frame_threshold_box, flag=wx.ALIGN_CENTER|wx.ALL, border=10)
-        
-        # Buttons
-        button_font = Theme.get_font(16)
-        
+        self._register_scalable(frame_threshold_label, Theme.FONT_BODY)
+        grid.Add(frame_threshold_label, flag=wx.ALIGN_CENTER_VERTICAL)
+
+        self.frameThresholdInput = wx.SpinCtrl(settings_card, value="10", min=1, max=100)
+        self.frameThresholdInput.SetFont(Theme.get_font(Theme.FONT_BODY))
+        gui_utils.style_native_input(self.frameThresholdInput)
+        self._register_scalable(self.frameThresholdInput, Theme.FONT_BODY)
+        grid.Add(self.frameThresholdInput, flag=wx.ALIGN_CENTER_VERTICAL)
+
+        settings.Add(grid, flag=wx.EXPAND)
+
+        actions_card = SectionCard(self.videoPanel, heading="Actions")
+        actions = actions_card.content_sizer
+        button_font = Theme.get_font(Theme.FONT_BUTTON)
+
         self.convertBtn, hbox_convert = TooltipButton.create_with_icon(
-            self.videoPanel, 
-            'Convert video to audio', 
+            actions_card,
+            'Convert video to audio',
             f'Converts video files ({self._format_supported_extensions(self.VIDEO_EXTENSIONS)}) to audio files (.wav) for further processing',
             font=button_font,
-            handler=self.on_convert
+            handler=self.on_convert,
+            variant=FlatButton.VARIANT_SECONDARY,
         )
-        video_sizer.Add(hbox_convert, flag=wx.ALIGN_CENTER|wx.ALL, border=10)
-        
+        self._register_scalable(self.convertBtn, Theme.FONT_BUTTON)
+        actions.Add(hbox_convert, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
         self.extractFeaturesBtn, hbox_extract_pose = TooltipButton.create_with_icon(
-            self.videoPanel,
+            actions_card,
             'Extract Pose Features',
             'Extracts human pose landmarks and features from video files using MediaPipe. Supports single and multi-person detection.',
             font=button_font,
-            handler=self.on_extract_features
+            handler=self.on_extract_features,
         )
-        video_sizer.Add(hbox_extract_pose, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        
+        self._register_scalable(self.extractFeaturesBtn, Theme.FONT_BUTTON)
+        actions.Add(hbox_extract_pose, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
         self.embedFeaturesBtn, hbox_embed_pose = TooltipButton.create_with_icon(
-            self.videoPanel,
+            actions_card,
             'Embed Pose Features',
             'Creates vector embeddings from extracted pose features for machine learning and analysis purposes.',
             font=button_font,
-            handler=self.on_embed_poses
+            handler=self.on_embed_poses,
+            variant=FlatButton.VARIANT_SECONDARY,
         )
-        video_sizer.Add(hbox_embed_pose, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        
+        self._register_scalable(self.embedFeaturesBtn, Theme.FONT_BUTTON)
+        actions.Add(hbox_embed_pose, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
         self.verifyBtn, hbox_verify = TooltipButton.create_with_icon(
-            self.videoPanel,
+            actions_card,
             'Verify Consistency',
             'Verifies that embedded videos match extracted pose CSVs and saves a report with worst-frame thumbnails.',
             font=button_font,
-            handler=self.on_verify_consistency
+            handler=self.on_verify_consistency,
+            variant=FlatButton.VARIANT_SECONDARY,
         )
-        video_sizer.Add(hbox_verify, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        video_sizer.AddSpacer(10)
-        
+        self._register_scalable(self.verifyBtn, Theme.FONT_BUTTON)
+        actions.Add(hbox_verify, flag=wx.EXPAND)
+
+        gap = self.FromDIP(Theme.SPACE_MD)
+        video_sizer.Add(settings_card, proportion=0, flag=wx.EXPAND)
+        video_sizer.Add((gap, gap))
+        video_sizer.Add(actions_card, proportion=0, flag=wx.EXPAND)
         self.videoPanel.SetSizer(video_sizer)
+        self._video_cards = (settings_card, actions_card)
 
     def _create_audio_panel(self):
         audio_sizer = wx.BoxSizer(wx.VERTICAL)
-        
-        # Placeholder
-        self.placeholderAudioLabel = gui_utils.create_transparent_text(self.audioPanel, label="If you have an audio file:")
-        self.placeholderAudioLabel.SetFont(Theme.get_font(20))
-        audio_sizer.AddSpacer(10)
-        audio_sizer.Add(self.placeholderAudioLabel, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        
-        # Diarization
-        self.diarizationCheckbox = wx.CheckBox(self.audioPanel, label="Enable speaker diarization")
-        self.diarizationCheckbox.SetFont(Theme.get_font(12))
-        self.diarizationCheckbox.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        gui_utils.style_checkbox_for_glass(self.diarizationCheckbox)
-        audio_sizer.Add(self.diarizationCheckbox, flag=wx.ALIGN_CENTER|wx.ALL, border=6)
 
-        # Word-level timestamps (precomputes the JSON sidecar that Align Features needs,
-        # so alignment doesn't have to re-run transcription on every file later)
-        self.wordTimestampsCheckbox = wx.CheckBox(self.audioPanel, label="Save word-level timestamps (for Align Features)")
-        self.wordTimestampsCheckbox.SetFont(Theme.get_font(12))
-        self.wordTimestampsCheckbox.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        gui_utils.style_checkbox_for_glass(self.wordTimestampsCheckbox)
-        audio_sizer.Add(self.wordTimestampsCheckbox, flag=wx.ALIGN_CENTER|wx.ALL, border=6)
+        settings_card = SectionCard(self.audioPanel, heading="Settings")
+        settings = settings_card.content_sizer
+
+        self.diarizationCheckbox = CustomCheckBox(settings_card, label="Enable speaker diarization")
+        self.diarizationCheckbox.SetFont(Theme.get_font(Theme.FONT_BODY))
+        self.diarizationCheckbox.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+        self._register_scalable(self.diarizationCheckbox, Theme.FONT_BODY)
+        settings.Add(self.diarizationCheckbox, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
+        self.wordTimestampsCheckbox = CustomCheckBox(
+            settings_card, label="Save word-level timestamps (for Align Features)"
+        )
+        self.wordTimestampsCheckbox.SetFont(Theme.get_font(Theme.FONT_BODY))
+        self.wordTimestampsCheckbox.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+        self._register_scalable(self.wordTimestampsCheckbox, Theme.FONT_BODY)
+        settings.Add(self.wordTimestampsCheckbox, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_MD)
 
         self.diarizationStatusLabel = gui_utils.create_transparent_text(
-            self.audioPanel,
+            settings_card,
             label="Diarization status: checking optional component...",
-            style=wx.ALIGN_CENTER,
+            style=wx.ALIGN_LEFT,
         )
-        self.diarizationStatusLabel.SetFont(Theme.get_font(11))
-        self.diarizationStatusLabel.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        audio_sizer.Add(self.diarizationStatusLabel, flag=wx.ALIGN_CENTER|wx.LEFT|wx.RIGHT|wx.BOTTOM, border=8)
+        self.diarizationStatusLabel.SetFont(Theme.get_font(Theme.FONT_CAPTION))
+        self.diarizationStatusLabel.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_MUTED))
+        self._register_scalable(self.diarizationStatusLabel, Theme.FONT_CAPTION)
+        settings.Add(self.diarizationStatusLabel, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
 
-        self.installDiarizationBtn = wx.Button(self.audioPanel, label="Install Complete Toolbox")
-        self.installDiarizationBtn.SetFont(Theme.get_font(11, bold=True))
+        self.installDiarizationBtn = FlatButton(
+            settings_card, label="Install Complete Toolbox", variant=FlatButton.VARIANT_SECONDARY
+        )
+        self.installDiarizationBtn.SetFont(Theme.get_font(Theme.FONT_CAPTION, bold=True))
         self.installDiarizationBtn.Bind(wx.EVT_BUTTON, self.on_install_diarization)
-        audio_sizer.Add(self.installDiarizationBtn, flag=wx.ALIGN_CENTER|wx.BOTTOM, border=10)
-        
-        # Buttons
-        button_font = Theme.get_font(16)
-        
+        self._register_scalable(self.installDiarizationBtn, Theme.FONT_CAPTION, bold=True)
+        settings.Add(self.installDiarizationBtn, flag=wx.ALIGN_LEFT)
+
+        actions_card = SectionCard(self.audioPanel, heading="Actions")
+        actions = actions_card.content_sizer
+        button_font = Theme.get_font(Theme.FONT_BUTTON)
+
         self.extractAudioFeaturesBtn, hbox_extract_audio = TooltipButton.create_with_icon(
-            self.audioPanel,
+            actions_card,
             'Extract Audio Features',
             f'Extracts acoustic features from supported audio files ({self._format_supported_extensions(self.AUDIO_EXTENSIONS)}) including MFCC, spectral features, and prosodic characteristics.',
             font=button_font,
-            handler=self.on_extract_audio_features
+            handler=self.on_extract_audio_features,
         )
-        audio_sizer.Add(hbox_extract_audio, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        
+        self._register_scalable(self.extractAudioFeaturesBtn, Theme.FONT_BUTTON)
+        actions.Add(hbox_extract_audio, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
         self.extractTranscriptsBtn, hbox_extract_transcripts = TooltipButton.create_with_icon(
-            self.audioPanel,
+            actions_card,
             'Extract Transcripts',
             f'Converts speech in supported audio files ({self._format_supported_extensions(self.AUDIO_EXTENSIONS)}) to text transcripts using automatic speech recognition (ASR) technology.',
             font=button_font,
-            handler=self.on_extract_transcripts
+            handler=self.on_extract_transcripts,
+            variant=FlatButton.VARIANT_SECONDARY,
         )
-        audio_sizer.Add(hbox_extract_transcripts, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        
+        self._register_scalable(self.extractTranscriptsBtn, Theme.FONT_BUTTON)
+        actions.Add(hbox_extract_transcripts, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
         self.alignFeaturesBtn, hbox_align = TooltipButton.create_with_icon(
-            self.audioPanel,
+            actions_card,
             'Align Features',
             'Aligns extracted audio features with word-level transcripts. Requires both features and transcripts.',
             font=button_font,
-            handler=self.on_align_features
+            handler=self.on_align_features,
+            variant=FlatButton.VARIANT_SECONDARY,
         )
-        audio_sizer.Add(hbox_align, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        audio_sizer.AddSpacer(10)
-        
+        self._register_scalable(self.alignFeaturesBtn, Theme.FONT_BUTTON)
+        actions.Add(hbox_align, flag=wx.EXPAND)
+
+        gap = self.FromDIP(Theme.SPACE_MD)
+        audio_sizer.Add(settings_card, proportion=0, flag=wx.EXPAND)
+        audio_sizer.Add((gap, gap))
+        audio_sizer.Add(actions_card, proportion=0, flag=wx.EXPAND)
         self.audioPanel.SetSizer(audio_sizer)
+        self._audio_cards = (settings_card, actions_card)
 
     def _create_status_and_progress(self, pnl, vbox):
-        self.statusLabel = gui_utils.create_transparent_text(pnl, label="", style=wx.ALIGN_CENTER_HORIZONTAL)
-        self.statusLabel.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        try:
-            self.statusLabel.SetFont(Theme.get_font(13, bold=True))
-        except Exception:
-            pass
-        vbox.Add(self.statusLabel, flag=wx.EXPAND|wx.ALL, border=10)
-        
-        self.progress = CustomGauge(pnl, range=100)
-        self.progress.SetMinSize((-1, self.FromDIP(30)))
-        try:
-            self.progress.SetForegroundColour(wx.Colour(33, 150, 243))
-        except Exception:
-            pass
-        vbox.Add(self.progress, proportion=0, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
+        self.footerCard = SectionCard(pnl, heading="Status")
+        footer_card = self.footerCard
+        footer = footer_card.content_sizer
+
+        self.statusLabel = gui_utils.create_transparent_text(
+            footer_card, label="", style=wx.ALIGN_LEFT
+        )
+        self.statusLabel.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+        self.statusLabel.SetFont(Theme.get_font(Theme.FONT_BODY, bold=True))
+        self._register_scalable(self.statusLabel, Theme.FONT_BODY, bold=True)
+        footer.Add(self.statusLabel, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
+        self.progress = CustomGauge(footer_card, range=100)
+        self.progress.SetMinSize((-1, self.FromDIP(34)))
+        footer.Add(self.progress, flag=wx.EXPAND | wx.BOTTOM, border=Theme.SPACE_SM)
+
+        self.cancelBtn = FlatButton(footer_card, label="Cancel", variant=FlatButton.VARIANT_DANGER)
+        self.cancelBtn.SetFont(Theme.get_font(Theme.FONT_BODY, bold=True))
+        self.cancelBtn.Bind(wx.EVT_BUTTON, self.on_cancel)
+        self.cancelBtn.Hide()
+        self._register_scalable(self.cancelBtn, Theme.FONT_BODY, bold=True)
+        footer.Add(self.cancelBtn, flag=wx.EXPAND)
+
+        vbox.Add(footer_card, flag=wx.ALIGN_CENTER_HORIZONTAL | wx.TOP | wx.BOTTOM, border=Theme.SPACE_LG)
 
     def _finalize_setup(self, vbox):
         # Capture a design baseline size
         best_min = vbox.CalcMin()
-        self._baseline_size = (max(400, best_min.width), max(800, best_min.height))
+        self._baseline_size = (max(400, best_min.width), max(640, best_min.height))
         
         self.Bind(wx.EVT_SIZE, self.on_resize)
         
@@ -407,50 +515,52 @@ class VideoToWavConverter(wx.Frame):
 
     def switch_mode(self, mode):
         self.active_mode = mode
-        # Remove old button background coloring for modern look
-        self.videoModeBtn.SetBackgroundColour(wx.NullColour)
-        self.audioModeBtn.SetBackgroundColour(wx.NullColour)
-        self.videoModeBtn.SetForegroundColour(wx.Colour(0, 0, 0))
-        self.audioModeBtn.SetForegroundColour(wx.Colour(0, 0, 0))
-        # Underline logic
+        if hasattr(self, "modeTabs") and self.modeTabs:
+            self.modeTabs.set_selected(mode)
         if mode == 'video':
             self.videoPanel.Show()
             self.audioPanel.Hide()
             self.folderCaption.SetLabel("Select a folder containing VIDEO files")
-            self.videoModeBtn.Enable(False)
-            self.audioModeBtn.Enable(True)
-            # Underline: show under video, hide under audio
-            self._video_underline.Show()
-            self._audio_underline.Hide()
         else:
             self.videoPanel.Hide()
             self.audioPanel.Show()
             self.folderCaption.SetLabel(
                 f"Select a folder containing AUDIO files ({self._format_supported_extensions(self.AUDIO_EXTENSIONS)})"
             )
-            self.videoModeBtn.Enable(True)
-            self.audioModeBtn.Enable(False)
-            # Underline: show under audio, hide under video
-            self._video_underline.Hide()
-            self._audio_underline.Show()
-        # Refresh button and underline appearance
-        self.videoModeBtn.Refresh()
-        self.audioModeBtn.Refresh()
-        self._video_underline.Refresh()
-        self._audio_underline.Refresh()
-        # Update panel sizes and relayout
         self._update_panel_sizes()
         self.Layout()
-        # Relayout parent panel as well
         pnl = self.GetChildren()[0] if self.GetChildren() else None
         if pnl and hasattr(pnl, "Layout"):
             pnl.Layout()
-        # Reset UX state on mode switch ONLY if no process is running
         if not self._process_running:
-            if hasattr(self, 'statusLabel'):
-                self.statusLabel.SetLabel("")
             self.update_progress(0)
+            self._refresh_idle_hint()
         self.update_buttons_enabled()
+
+    def _refresh_idle_hint(self):
+        """Empty/idle-state guidance in the STATUS line: prompts for a folder,
+        warns when none match, or confirms how many files are ready."""
+        if self._process_running or not hasattr(self, 'statusLabel'):
+            return
+        folder = self.get_selected_folder_path()
+        kind = "video" if self.active_mode == 'video' else "audio"
+        if not folder:
+            self.set_status_message("Select a data folder to begin.")
+            return
+        try:
+            if self.active_mode == 'video':
+                files = gui_utils.get_files_from_folder(
+                    gui_utils.resolved_dataset_root(folder), self.VIDEO_EXTENSIONS
+                )
+            else:
+                files = gui_utils.get_audio_files_for_processing(folder, self.AUDIO_EXTENSIONS)
+        except Exception:
+            files = []
+        n = len(files)
+        if n == 0:
+            self.set_status_message(f"No {kind} files found in this folder.")
+        else:
+            self.set_status_message(f"Ready — {n} {kind} file{'s' if n != 1 else ''} found.")
 
     def on_folder_changed(self, event):
         normalized_path = self.get_selected_folder_path()
@@ -461,6 +571,7 @@ class VideoToWavConverter(wx.Frame):
                 pass
         self.ensure_output_folders(normalized_path)
         self.update_buttons_enabled()
+        self._refresh_idle_hint()
 
     def get_selected_folder_path(self):
         return gui_utils.normalize_path(self.folderPicker.GetPath())
@@ -513,7 +624,9 @@ class VideoToWavConverter(wx.Frame):
             self.diarizationCheckbox.SetValue(False)
         self.diarizationStatusLabel.SetLabel(status_label)
         self.installDiarizationBtn.SetLabel(button_label)
-        self.installDiarizationBtn.Enable(button_enabled and not self._diarization_install_running)
+        self.installDiarizationBtn.Enable(
+            button_enabled and not self._diarization_install_running and self._folder_allows_controls()
+        )
 
         try:
             self.audioPanel.Layout()
@@ -523,38 +636,91 @@ class VideoToWavConverter(wx.Frame):
             pass
 
     def _update_panel_sizes(self):
-        # Keep panels at a reasonable width fraction of the frame
+        """Size the centered content column and choose 1- vs 2-column panel layout.
+
+        Below the breakpoint the Settings/Actions cards stack (narrow column);
+        at/above it they sit side-by-side and the column widens to use the frame,
+        which removes the large side margins on desktop-sized windows.
+        """
         if not hasattr(self, 'videoPanel') or not hasattr(self, 'audioPanel'):
             return
         try:
-            cur_w, cur_h = self.GetSize()
-            target_w = max(380, int(cur_w * 0.60))
-            # Cap to avoid overly wide panels on very large screens
-            target_w = min(target_w, 900)
-            # Let each panel size itself based on content, with a min/max cap
-            if self.videoPanel:
-                self.videoPanel.SetMinSize((target_w, -1))
-                self.videoPanel.SetMaxSize((target_w, -1))
-            if self.audioPanel:
-                self.audioPanel.SetMinSize((target_w, -1))
-                self.audioPanel.SetMaxSize((target_w, -1))
-            # Match folder picker width to glass panels
-            if hasattr(self, 'folderPicker') and self.folderPicker:
-                self.folderPicker.SetMinSize((target_w, -1))
-                self.folderPicker.SetMaxSize((target_w, -1))
-            # Match progress bar width to glass panels
-            if hasattr(self, 'progress') and self.progress:
-                # Keep height fixed at initialized value (30 scaled), only adjust width
-                current_min_size = self.progress.GetMinSize()
-                self.progress.SetMinSize((target_w, current_min_size.height))
-                self.progress.SetMaxSize((target_w, current_min_size.height))
+            cur_w, _cur_h = self.GetSize()
+            horizontal = cur_w >= self.FromDIP(860)
+            if horizontal:
+                target_w = min(int(cur_w * 0.90), self.FromDIP(1180))
+                target_w = max(target_w, self.FromDIP(720))
+            else:
+                target_w = min(max(self.FromDIP(360), int(cur_w * 0.70)), self.FromDIP(640))
+
+            # All content blocks share one width so their edges align.
+            tab_h = self.FromDIP(50)
+            for block in (
+                getattr(self, 'headerBar', None),
+                getattr(self, 'modeTabs', None),
+                getattr(self, 'folderCard', None),
+                self.videoPanel,
+                self.audioPanel,
+                getattr(self, 'footerCard', None),
+            ):
+                if not block:
+                    continue
+                if block is getattr(self, 'modeTabs', None):
+                    block.SetMinSize((target_w, tab_h))
+                    block.SetMaxSize((target_w, tab_h))
+                else:
+                    block.SetMinSize((target_w, -1))
+                    block.SetMaxSize((target_w, 10000))
+
+            self._apply_panel_orientation(horizontal)
         except Exception:
             pass
 
+    def _apply_panel_orientation(self, horizontal):
+        """Rebuild each panel's sizer only when the 1-/2-column mode flips.
+
+        A fresh BoxSizer (rather than SetOrientation) keeps this working across
+        wxPython versions. Cards are reused — only the sizer is replaced."""
+        if horizontal == self._panels_horizontal:
+            return
+        pairs = (
+            (self.videoPanel, getattr(self, '_video_cards', None)),
+            (self.audioPanel, getattr(self, '_audio_cards', None)),
+        )
+        try:
+            for panel, cards in pairs:
+                if not panel or not cards:
+                    continue
+                settings_card, actions_card = cards
+                gap = self.FromDIP(Theme.SPACE_MD)
+                if horizontal:
+                    # Equal-width columns, each at its natural height (top-aligned)
+                    # so the shorter Settings card doesn't stretch with empty space.
+                    sizer = wx.BoxSizer(wx.HORIZONTAL)
+                    card_flag = wx.ALIGN_TOP
+                    proportion = 1
+                else:
+                    sizer = wx.BoxSizer(wx.VERTICAL)
+                    card_flag = wx.EXPAND
+                    proportion = 0
+                sizer.Add(settings_card, proportion=proportion, flag=card_flag)
+                sizer.Add((gap, gap))
+                sizer.Add(actions_card, proportion=proportion, flag=card_flag)
+                panel.SetSizer(sizer, deleteOld=True)
+                panel.Layout()
+            self._panels_horizontal = horizontal
+        except Exception:
+            # Leave whatever orientation is currently applied; never crash layout.
+            pass
+
+    def _folder_allows_controls(self):
+        return bool(self.get_selected_folder_path())
+
     def update_buttons_enabled(self):
+        if self._process_running:
+            return
         folder_path = self.get_selected_folder_path()
         has_folder = bool(folder_path)
-        # Detect files
         video_files = []
         audio_files = []
         try:
@@ -564,113 +730,85 @@ class VideoToWavConverter(wx.Frame):
                 audio_files = gui_utils.get_audio_files_for_processing(folder_path, self.AUDIO_EXTENSIONS)
         except Exception:
             pass
-        # Video buttons
+
         enable_video = has_folder and len(video_files) > 0
-        for btn in [getattr(self, 'convertBtn', None), getattr(self, 'extractFeaturesBtn', None), getattr(self, 'embedFeaturesBtn', None), getattr(self, 'verifyBtn', None)]:
+        enable_audio = has_folder and len(audio_files) > 0
+
+        for ctrl in [
+            getattr(self, 'multiPersonCheckbox', None),
+            getattr(self, 'downscaleCheckbox', None),
+            getattr(self, 'frameStrideInput', None),
+            getattr(self, 'frameThresholdInput', None),
+            getattr(self, 'diarizationCheckbox', None),
+            getattr(self, 'wordTimestampsCheckbox', None),
+        ]:
+            if ctrl is not None:
+                ctrl.Enable(has_folder)
+
+        for btn in [
+            getattr(self, 'convertBtn', None),
+            getattr(self, 'extractFeaturesBtn', None),
+            getattr(self, 'embedFeaturesBtn', None),
+            getattr(self, 'verifyBtn', None),
+        ]:
             if btn:
                 btn.Enable(enable_video)
-        # Audio buttons
-        enable_audio = has_folder and len(audio_files) > 0
-        for btn in [getattr(self, 'extractAudioFeaturesBtn', None), getattr(self, 'extractTranscriptsBtn', None), getattr(self, 'alignFeaturesBtn', None)]:
+
+        for btn in [
+            getattr(self, 'extractAudioFeaturesBtn', None),
+            getattr(self, 'extractTranscriptsBtn', None),
+            getattr(self, 'alignFeaturesBtn', None),
+        ]:
             if btn:
                 btn.Enable(enable_audio)
-        
-    def _scale_font(self, base_point_size, scale):
-        new_size = max(9, int(round(base_point_size * scale)))
-        return Theme.get_font(new_size)
 
-    def _scale_bold_font(self, base_point_size, scale):
-        new_size = max(10, int(round(base_point_size * scale)))
-        return Theme.get_font(new_size, bold=True)
-
+        self.refresh_diarization_state()
     def on_resize(self, event):
-        # Establish baseline once
         if self._baseline_size is None:
             self._baseline_size = self.GetSize()
         cur_w, cur_h = self.GetSize()
         base_w, base_h = self._baseline_size
-        # Compute scale preserving aspect
-        # Do not scale down below baseline; allow growth only and use scrollbars when smaller
         scale_w = max(cur_w / max(1, base_w), 1.0)
         scale_h = max(cur_h / max(1, base_h), 1.0)
-        scale = min(scale_w, scale_h, 2.0)
+        # Cap growth tightly: typography should stay consistent across window sizes
+        # (responsive layout, not ballooning fonts, fills large windows). 2x looked
+        # inconsistent and could overflow fixed-width cards.
+        scale = min(scale_w, scale_h, 1.25)
 
-        # Scale title and logo fonts
         try:
-            if hasattr(self, 'title') and self.title:
-                self.title.SetFont(self._scale_font(20, scale))
-            if hasattr(self, 'logoLabel') and self.logoLabel:
-                self.logoLabel.SetFont(self._scale_bold_font(24, scale))
-            if hasattr(self, 'placeholderVideoLabel') and self.placeholderVideoLabel:
-                self.placeholderVideoLabel.SetFont(self._scale_font(20, scale))
-            if hasattr(self, 'placeholderAudioLabel') and self.placeholderAudioLabel:
-                self.placeholderAudioLabel.SetFont(self._scale_font(20, scale))
-            if hasattr(self, 'folderCaption') and self.folderCaption:
-                self.folderCaption.SetFont(self._scale_font(13, scale))
+            for widget, base_size, bold in self._scalable_widgets:
+                if not widget:
+                    continue
+                # Some registered targets are lightweight font proxies (segmented
+                # tab labels) with no IsShown(); treat those as always visible and
+                # never let one widget abort the whole scaling pass.
                 try:
-                    wrap_width = max(240, int(cur_w * 0.6))
-                    self.folderCaption.Wrap(wrap_width)
+                    is_shown = widget.IsShown() if hasattr(widget, "IsShown") else True
+                    if is_shown:
+                        new_size = max(9, int(round(base_size * scale)))
+                        widget.SetFont(Theme.get_font(new_size, bold=bold))
+                except Exception:
+                    continue
+            if hasattr(self, 'folderCaption') and self.folderCaption:
+                try:
+                    self.folderCaption.Wrap(max(240, int(cur_w * 0.6)))
                 except Exception:
                     pass
-            # Mode toggle buttons
-            if hasattr(self, 'videoModeBtn') and self.videoModeBtn:
-                self.videoModeBtn.SetFont(self._scale_font(11, scale))
-            if hasattr(self, 'audioModeBtn') and self.audioModeBtn:
-                self.audioModeBtn.SetFont(self._scale_font(11, scale))
-            if hasattr(self, 'multiPersonCheckbox') and self.multiPersonCheckbox:
-                self.multiPersonCheckbox.SetFont(self._scale_font(14, scale))
-            if hasattr(self, 'diarizationCheckbox') and self.diarizationCheckbox:
-                self.diarizationCheckbox.SetFont(self._scale_font(12, scale))
-            if hasattr(self, 'wordTimestampsCheckbox') and self.wordTimestampsCheckbox:
-                self.wordTimestampsCheckbox.SetFont(self._scale_font(12, scale))
             if hasattr(self, 'diarizationStatusLabel') and self.diarizationStatusLabel:
-                self.diarizationStatusLabel.SetFont(self._scale_font(11, scale))
                 try:
                     self.diarizationStatusLabel.Wrap(max(240, int(cur_w * 0.55)))
                 except Exception:
                     pass
-            if hasattr(self, 'frameStrideInput'):
-                self.frameStrideInput.SetFont(self._scale_font(12, scale))
-            if hasattr(self, 'downscaleCheckbox'):
-                self.downscaleCheckbox.SetFont(self._scale_font(12, scale))
-            # Frame threshold elements
-            if hasattr(self, 'frameThresholdInput'):
-                self.frameThresholdInput.SetFont(self._scale_font(12, scale))
-            # Buttons (safely check existence)
-            button_font = self._scale_font(16, scale)
-            if hasattr(self, 'convertBtn') and self.convertBtn:
-                self.convertBtn.SetFont(button_font)
-            if hasattr(self, 'extractFeaturesBtn') and self.extractFeaturesBtn:
-                self.extractFeaturesBtn.SetFont(button_font)
-            if hasattr(self, 'embedFeaturesBtn') and self.embedFeaturesBtn:
-                self.embedFeaturesBtn.SetFont(button_font)
-            if hasattr(self, 'verifyBtn') and self.verifyBtn:
-                self.verifyBtn.SetFont(button_font)
-            if hasattr(self, 'extractAudioFeaturesBtn') and self.extractAudioFeaturesBtn:
-                self.extractAudioFeaturesBtn.SetFont(button_font)
-            if hasattr(self, 'extractTranscriptsBtn') and self.extractTranscriptsBtn:
-                self.extractTranscriptsBtn.SetFont(button_font)
-            if hasattr(self, 'alignFeaturesBtn') and self.alignFeaturesBtn:
-                self.alignFeaturesBtn.SetFont(button_font)
-            if hasattr(self, 'installDiarizationBtn') and self.installDiarizationBtn:
-                self.installDiarizationBtn.SetFont(self._scale_font(11, scale))
-            # Status label: scale font and wrap to panel width for responsiveness
             if hasattr(self, 'statusLabel') and self.statusLabel:
-                self.statusLabel.SetFont(self._scale_font(12, scale))
                 try:
                     wrap_width = max(200, int(cur_w * 0.9))
                     self.statusLabel.Wrap(wrap_width)
-                    # Re-apply centering after Wrap, which can reset alignment
                     self.statusLabel.SetWindowStyleFlag(wx.ALIGN_CENTER_HORIZONTAL)
                 except Exception:
                     pass
-            # Progress bar height scaling - REMOVED to ensure consistency
-            # if hasattr(self, 'progress') and self.progress:
-            #     self.progress.SetMinSize((-1, max(self.FromDIP(20), int(self.FromDIP(28) * scale))))
         except Exception:
             pass
 
-        # Relayout after scaling
         self._update_panel_sizes()
         self.mainPanel.Layout()
         self.mainPanel.FitInside()
@@ -874,26 +1012,28 @@ class VideoToWavConverter(wx.Frame):
             return
 
         # Process each video file in a separate thread
+        self._begin_process()
         thread = threading.Thread(target=self.convert_all_videos_to_wav, args=(video_files,))
         thread.start()
 
     def convert_all_videos_to_wav(self, video_files):
         """Convert multiple videos to WAV format and save to output folder."""
-        self._process_running = True
+        cancelled = False
         try:
             total_files = len(video_files)
-        
+
             for i, video_file in enumerate(video_files):
+                if self._cancel_event.is_set():
+                    cancelled = True
+                    break
                 file_name = os.path.basename(video_file)
                 self.set_status_message(f"Converting to WAV: {file_name}")
-                
-                # Overall progress callback (percent-based)
                 self.convert_to_wav(video_file, progress_callback=self.make_overall_progress_cb(i + 1, total_files))
 
-            wx.MessageBox("Video to audio conversion completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+            if not cancelled:
+                wx.CallAfter(wx.MessageBox, "Video to audio conversion completed!", "Success", wx.OK | wx.ICON_INFORMATION)
         finally:
-            self._process_running = False
-            self.update_progress(0)  # Reset progress bar
+            wx.CallAfter(self._end_process, cancelled)
 
     def on_verify_consistency(self, event):
         folder_path = self.get_selected_folder_path()
@@ -919,6 +1059,7 @@ class VideoToWavConverter(wx.Frame):
             return
 
         # Launch background verification to keep UI responsive
+        self._begin_process()
         thread = threading.Thread(target=self._verify_consistency_batch, args=(embedded_videos, verification_dir, worst_frames_root))
         thread.start()
 
@@ -926,11 +1067,14 @@ class VideoToWavConverter(wx.Frame):
         from verify_pose_embedding import verify, save_report
         import glob
 
-        self._process_running = True
+        cancelled = False
         try:
             summary = []
             total = len(embedded_videos)
             for i, video in enumerate(embedded_videos, start=1):
+                if self._cancel_event.is_set():
+                    cancelled = True
+                    break
                 base = os.path.splitext(os.path.basename(video))[0]
                 # Remove trailing "_pose" if present to get CSV base
                 csv_base = base.replace("_pose", "")
@@ -989,10 +1133,10 @@ class VideoToWavConverter(wx.Frame):
             except Exception:
                 pass
 
-            wx.CallAfter(wx.MessageBox, "Verification completed! See the 'verification' folder for reports.", "Success", wx.OK | wx.ICON_INFORMATION)
+            if not cancelled:
+                wx.CallAfter(wx.MessageBox, "Verification completed! See the 'verification' folder for reports.", "Success", wx.OK | wx.ICON_INFORMATION)
         finally:
-            self._process_running = False
-            self.update_progress(0)
+            wx.CallAfter(self._end_process, cancelled)
 
     def convert_to_wav(self, filepath, progress_callback=None):
         """Convert a single video file to WAV using ffmpeg."""
@@ -1085,25 +1229,34 @@ class VideoToWavConverter(wx.Frame):
             )
             return
 
+        self._begin_process()
         thread = threading.Thread(target=self.extract_pose_features_batch, args=(video_files, pose_processor))
         thread.start()
 
     def extract_pose_features_batch(self, video_files, pose_processor):
         """Batch process all video files to extract pose features."""
-        self._process_running = True
+        cancelled = False
         try:
             total_files = len(video_files)
 
             for index, video_file in enumerate(video_files, start=1):
-                self.set_status_message(f"📸 Extracting pose from: {os.path.basename(video_file)}")
-                
-                # Overall progress callback (percent-based)
-                pose_processor.extract_pose_features(video_file, progress_callback=self.make_overall_progress_cb(index, total_files))
+                if self._cancel_event.is_set():
+                    cancelled = True
+                    break
+                self.set_status_message(f"Extracting pose from: {os.path.basename(video_file)}")
+                result = pose_processor.extract_pose_features(
+                    video_file,
+                    progress_callback=self.make_overall_progress_cb(index, total_files),
+                    cancel_check=self._cancel_event.is_set,
+                )
+                if result is False:
+                    cancelled = True
+                    break
 
-            wx.CallAfter(wx.MessageBox, "Pose feature extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+            if not cancelled:
+                wx.CallAfter(wx.MessageBox, "Pose feature extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
         finally:
-            self._process_running = False
-            self.update_progress(0)  # Reset progress bar
+            wx.CallAfter(self._end_process, cancelled)
             
            
     def on_embed_poses(self, event):
@@ -1162,24 +1315,33 @@ class VideoToWavConverter(wx.Frame):
             )
             return
 
+        self._begin_process()
         thread = threading.Thread(target=self.embed_pose_batch, args=(video_files, pose_processor))
         thread.start()
 
     def embed_pose_batch(self, video_files, pose_processor):
-        self._process_running = True
+        cancelled = False
         try:
             total_files = len(video_files)
 
             for index, video_file in enumerate(video_files, start=1):
-                self.set_status_message(f"🕺 Embedding poses for: {os.path.basename(video_file)}")
-                
-                # Overall progress callback (percent-based)
-                pose_processor.embed_pose_video(video_file, progress_callback=self.make_overall_progress_cb(index, total_files))
+                if self._cancel_event.is_set():
+                    cancelled = True
+                    break
+                self.set_status_message(f"Embedding poses for: {os.path.basename(video_file)}")
+                result = pose_processor.embed_pose_video(
+                    video_file,
+                    progress_callback=self.make_overall_progress_cb(index, total_files),
+                    cancel_check=self._cancel_event.is_set,
+                )
+                if result is False:
+                    cancelled = True
+                    break
 
-            wx.CallAfter(wx.MessageBox, "Pose embedding completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+            if not cancelled:
+                wx.CallAfter(wx.MessageBox, "Pose embedding completed!", "Success", wx.OK | wx.ICON_INFORMATION)
         finally:
-            self._process_running = False
-            self.update_progress(0)  # Reset progress bar
+            wx.CallAfter(self._end_process, cancelled)
 
 
     
@@ -1213,23 +1375,32 @@ class VideoToWavConverter(wx.Frame):
             status_callback=self.set_status_message
         )
 
+        self._begin_process()
         thread = threading.Thread(target=self.extract_audio_features_batch, args=(audio_files, audio_processor))
         thread.start()
 
     def extract_audio_features_batch(self, audio_files, audio_processor):
         """Batch process all audio files to extract features."""
-        self._process_running = True
+        cancelled = False
         try:
             def progress_callback(progress):
                 self.update_progress(progress)
-            
-            audio_processor.extract_audio_features_batch(audio_files, progress_callback=progress_callback)
-            wx.CallAfter(wx.MessageBox, "Audio feature extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+
+            audio_processor.extract_audio_features_batch(
+                audio_files,
+                progress_callback=progress_callback,
+                cancel_check=self._cancel_event.is_set,
+            )
+            cancelled = self._cancel_event.is_set()
+            if not cancelled:
+                wx.CallAfter(wx.MessageBox, "Audio feature extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
         except Exception as e:
-            wx.CallAfter(wx.MessageBox, f"Error during audio feature extraction: {e}", "Error", wx.OK | wx.ICON_ERROR)
+            if not self._cancel_event.is_set():
+                wx.CallAfter(wx.MessageBox, f"Error during audio feature extraction: {e}", "Error", wx.OK | wx.ICON_ERROR)
+            else:
+                cancelled = True
         finally:
-            self._process_running = False
-            self.update_progress(0)  # Reset progress bar
+            wx.CallAfter(self._end_process, cancelled)
 
 
 
@@ -1338,6 +1509,7 @@ class VideoToWavConverter(wx.Frame):
         )
 
         # Run transcription in a separate thread
+        self._begin_process()
         thread = threading.Thread(
             target=self.extract_transcripts_batch,
             args=(audio_files, audio_processor, word_timestamps),
@@ -1347,20 +1519,27 @@ class VideoToWavConverter(wx.Frame):
 
     def extract_transcripts_batch(self, audio_files, audio_processor, word_timestamps=False):
         """Batch process all audio files to generate transcripts."""
-        self._process_running = True
+        cancelled = False
         try:
             def progress_callback(progress):
                 self.update_progress(progress)
 
             audio_processor.extract_transcripts_batch(
-                audio_files, progress_callback=progress_callback, word_timestamps=word_timestamps
+                audio_files,
+                progress_callback=progress_callback,
+                word_timestamps=word_timestamps,
+                cancel_check=self._cancel_event.is_set,
             )
-            wx.CallAfter(wx.MessageBox, "Transcription extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+            cancelled = self._cancel_event.is_set()
+            if not cancelled:
+                wx.CallAfter(wx.MessageBox, "Transcription extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
         except Exception as e:
-            wx.CallAfter(wx.MessageBox, f"Error during transcript extraction: {e}", "Error", wx.OK | wx.ICON_ERROR)
+            if not self._cancel_event.is_set():
+                wx.CallAfter(wx.MessageBox, f"Error during transcript extraction: {e}", "Error", wx.OK | wx.ICON_ERROR)
+            else:
+                cancelled = True
         finally:
-            self._process_running = False
-            self.update_progress(0)  # Reset progress bar
+            wx.CallAfter(self._end_process, cancelled)
 
     def on_align_features(self, event):
         folder_path = self.get_selected_folder_path()
@@ -1383,11 +1562,12 @@ class VideoToWavConverter(wx.Frame):
             return
 
         # Run in thread
+        self._begin_process()
         thread = threading.Thread(target=self.align_features_batch, args=(audio_files,))
         thread.start()
 
     def align_features_batch(self, audio_files):
-        self._process_running = True
+        cancelled = False
         try:
             total_files = len(audio_files)
             
@@ -1405,6 +1585,9 @@ class VideoToWavConverter(wx.Frame):
             prep_errors = []  # (base_name, reason) for files we couldn't prepare
 
             for i, audio_file in enumerate(audio_files, start=1):
+                if self._cancel_event.is_set():
+                    cancelled = True
+                    break
                 base_name = os.path.splitext(os.path.basename(audio_file))[0]
 
                 # 1. Ensure we have word-level transcript (JSON)
@@ -1450,7 +1633,9 @@ class VideoToWavConverter(wx.Frame):
 
                 self.update_progress(int((i / total_files) * 50)) # First 50% for prep
 
-            if not alignment_pairs:
+            if cancelled:
+                pass
+            elif not alignment_pairs:
                 detail = "\n".join(f"• {name}: {reason}" for name, reason in prep_errors[:10])
                 if len(prep_errors) > 10:
                     detail += f"\n…and {len(prep_errors) - 10} more (see console/log)."
@@ -1458,26 +1643,27 @@ class VideoToWavConverter(wx.Frame):
                 if detail:
                     message += "\n\nWhat went wrong:\n" + detail
                 wx.CallAfter(wx.MessageBox, message, "Warning", wx.OK | wx.ICON_WARNING)
-                return
-
-            # Run alignment
-            audio_processor.align_features_batch(
-                alignment_pairs,
-                progress_callback=lambda p: self.update_progress(50 + int(p/2))
-            )
-
-            success_message = f"Feature alignment completed for {len(alignment_pairs)} file(s)!"
-            if prep_errors:
-                success_message += (
-                    f"\n\n{len(prep_errors)} file(s) were skipped (see console/log for details)."
+            elif not self._cancel_event.is_set():
+                audio_processor.align_features_batch(
+                    alignment_pairs,
+                    progress_callback=lambda p: self.update_progress(50 + int(p / 2)),
                 )
-            wx.CallAfter(wx.MessageBox, success_message, "Success", wx.OK | wx.ICON_INFORMATION)
+                success_message = f"Feature alignment completed for {len(alignment_pairs)} file(s)!"
+                if prep_errors:
+                    success_message += (
+                        f"\n\n{len(prep_errors)} file(s) were skipped (see console/log for details)."
+                    )
+                wx.CallAfter(wx.MessageBox, success_message, "Success", wx.OK | wx.ICON_INFORMATION)
+            else:
+                cancelled = True
             
         except Exception as e:
-            wx.CallAfter(wx.MessageBox, f"Alignment failed: {e}", "Error", wx.OK | wx.ICON_ERROR)
+            if not self._cancel_event.is_set():
+                wx.CallAfter(wx.MessageBox, f"Alignment failed: {e}", "Error", wx.OK | wx.ICON_ERROR)
+            else:
+                cancelled = True
         finally:
-            self._process_running = False
-            self.update_progress(0)
+            wx.CallAfter(self._end_process, cancelled)
 
 def main():
     if os.environ.get("MULTISOCIAL_IMPORT_SMOKE_TEST") == "1":

--- a/src/app.py
+++ b/src/app.py
@@ -292,6 +292,14 @@ class VideoToWavConverter(wx.Frame):
         gui_utils.style_checkbox_for_glass(self.diarizationCheckbox)
         audio_sizer.Add(self.diarizationCheckbox, flag=wx.ALIGN_CENTER|wx.ALL, border=6)
 
+        # Word-level timestamps (precomputes the JSON sidecar that Align Features needs,
+        # so alignment doesn't have to re-run transcription on every file later)
+        self.wordTimestampsCheckbox = wx.CheckBox(self.audioPanel, label="Save word-level timestamps (for Align Features)")
+        self.wordTimestampsCheckbox.SetFont(Theme.get_font(12))
+        self.wordTimestampsCheckbox.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
+        gui_utils.style_checkbox_for_glass(self.wordTimestampsCheckbox)
+        audio_sizer.Add(self.wordTimestampsCheckbox, flag=wx.ALIGN_CENTER|wx.ALL, border=6)
+
         self.diarizationStatusLabel = gui_utils.create_transparent_text(
             self.audioPanel,
             label="Diarization status: checking optional component...",
@@ -613,6 +621,8 @@ class VideoToWavConverter(wx.Frame):
                 self.multiPersonCheckbox.SetFont(self._scale_font(14, scale))
             if hasattr(self, 'diarizationCheckbox') and self.diarizationCheckbox:
                 self.diarizationCheckbox.SetFont(self._scale_font(12, scale))
+            if hasattr(self, 'wordTimestampsCheckbox') and self.wordTimestampsCheckbox:
+                self.wordTimestampsCheckbox.SetFont(self._scale_font(12, scale))
             if hasattr(self, 'diarizationStatusLabel') and self.diarizationStatusLabel:
                 self.diarizationStatusLabel.SetFont(self._scale_font(11, scale))
                 try:
@@ -1321,19 +1331,30 @@ class VideoToWavConverter(wx.Frame):
                 )
                 audio_processor.enable_speaker_diarization = False
 
+        # Word-level timestamps are opt-in: they precompute the JSON sidecar Align Features
+        # needs, so alignment doesn't have to re-run transcription file-by-file later.
+        word_timestamps = bool(
+            hasattr(self, 'wordTimestampsCheckbox') and self.wordTimestampsCheckbox.GetValue()
+        )
+
         # Run transcription in a separate thread
-        thread = threading.Thread(target=self.extract_transcripts_batch, args=(audio_files, audio_processor))
+        thread = threading.Thread(
+            target=self.extract_transcripts_batch,
+            args=(audio_files, audio_processor, word_timestamps),
+        )
         thread.start()
 
 
-    def extract_transcripts_batch(self, audio_files, audio_processor):
+    def extract_transcripts_batch(self, audio_files, audio_processor, word_timestamps=False):
         """Batch process all audio files to generate transcripts."""
         self._process_running = True
         try:
             def progress_callback(progress):
                 self.update_progress(progress)
-            
-            audio_processor.extract_transcripts_batch(audio_files, progress_callback=progress_callback)
+
+            audio_processor.extract_transcripts_batch(
+                audio_files, progress_callback=progress_callback, word_timestamps=word_timestamps
+            )
             wx.CallAfter(wx.MessageBox, "Transcription extraction completed!", "Success", wx.OK | wx.ICON_INFORMATION)
         except Exception as e:
             wx.CallAfter(wx.MessageBox, f"Error during transcript extraction: {e}", "Error", wx.OK | wx.ICON_ERROR)
@@ -1381,10 +1402,11 @@ class VideoToWavConverter(wx.Frame):
             )
             
             alignment_pairs = []
-            
+            prep_errors = []  # (base_name, reason) for files we couldn't prepare
+
             for i, audio_file in enumerate(audio_files, start=1):
                 base_name = os.path.splitext(os.path.basename(audio_file))[0]
-                
+
                 # 1. Ensure we have word-level transcript (JSON)
                 json_path = os.path.join(self.extracted_transcripts_folder, f"{base_name}_words.json")
                 if not os.path.exists(json_path):
@@ -1394,8 +1416,15 @@ class VideoToWavConverter(wx.Frame):
                         audio_processor.extract_transcript(audio_file, word_timestamps=True)
                     except Exception as e:
                         print(f"Failed to generate transcript for {base_name}: {e}")
+                        prep_errors.append((base_name, f"transcript failed: {e}"))
                         continue
-                
+                    # extract_transcript only warns (doesn't raise) if the JSON can't be
+                    # written, so confirm the sidecar actually exists before pairing it.
+                    if not os.path.exists(json_path):
+                        print(f"Word-level JSON was not produced for {base_name}; skipping.")
+                        prep_errors.append((base_name, "word-level JSON was not produced"))
+                        continue
+
                 # 2. Ensure we have features CSV
                 # Feature files are usually named {base_name}.csv or similar in extracted_audio_folder
                 # The AudioProcessor.extract_audio_features saves them as {base_name}.csv
@@ -1408,28 +1437,41 @@ class VideoToWavConverter(wx.Frame):
                         # Verify the file was created
                         if not os.path.exists(feature_csv):
                             print(f"Feature extraction completed but file not found: {feature_csv}, skipping.")
+                            prep_errors.append((base_name, "feature CSV was not produced"))
                             continue
                     except Exception as e:
                         print(f"Failed to extract features for {base_name}: {e}")
+                        prep_errors.append((base_name, f"feature extraction failed: {e}"))
                         continue
-                        
+
                 # 3. Output path
                 output_csv = os.path.join(self.extracted_audio_folder, f"{base_name}_aligned.csv")
                 alignment_pairs.append((feature_csv, json_path, output_csv))
-                
+
                 self.update_progress(int((i / total_files) * 50)) # First 50% for prep
 
             if not alignment_pairs:
-                wx.CallAfter(wx.MessageBox, "No valid pairs found to align. Ensure you have extracted audio features.", "Warning", wx.OK | wx.ICON_WARNING)
+                detail = "\n".join(f"• {name}: {reason}" for name, reason in prep_errors[:10])
+                if len(prep_errors) > 10:
+                    detail += f"\n…and {len(prep_errors) - 10} more (see console/log)."
+                message = "No valid pairs found to align. Ensure you have extracted audio features."
+                if detail:
+                    message += "\n\nWhat went wrong:\n" + detail
+                wx.CallAfter(wx.MessageBox, message, "Warning", wx.OK | wx.ICON_WARNING)
                 return
 
             # Run alignment
             audio_processor.align_features_batch(
-                alignment_pairs, 
+                alignment_pairs,
                 progress_callback=lambda p: self.update_progress(50 + int(p/2))
             )
-            
-            wx.CallAfter(wx.MessageBox, "Feature alignment completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+
+            success_message = f"Feature alignment completed for {len(alignment_pairs)} file(s)!"
+            if prep_errors:
+                success_message += (
+                    f"\n\n{len(prep_errors)} file(s) were skipped (see console/log for details)."
+                )
+            wx.CallAfter(wx.MessageBox, success_message, "Success", wx.OK | wx.ICON_INFORMATION)
             
         except Exception as e:
             wx.CallAfter(wx.MessageBox, f"Alignment failed: {e}", "Error", wx.OK | wx.ICON_ERROR)

--- a/src/audio.py
+++ b/src/audio.py
@@ -243,17 +243,20 @@ class AudioProcessor:
             print(error_msg)
             raise Exception(error_msg)
 
-    def extract_audio_features_batch(self, audio_files, progress_callback=None):
+    def extract_audio_features_batch(self, audio_files, progress_callback=None, cancel_check=None):
         """
         Batch process multiple audio files to extract features.
         
         Args:
             audio_files (list): List of paths to WAV files
             progress_callback (callable, optional): Callback function for progress updates
+            cancel_check (callable, optional): Return True to stop before the next file
         """
         total_files = len(audio_files)
         
         for i, audio_file in enumerate(audio_files):
+            if cancel_check and cancel_check():
+                break
             self.set_status_message(f"🎧 Extracting audio features from: {os.path.basename(audio_file)}")
             print(f"Extracting features from: {audio_file}")
             
@@ -832,7 +835,7 @@ class AudioProcessor:
             
         return "UNKNOWN"
 
-    def extract_transcripts_batch(self, audio_files, progress_callback=None, word_timestamps=False):
+    def extract_transcripts_batch(self, audio_files, progress_callback=None, word_timestamps=False, cancel_check=None):
         """
         Batch process multiple audio files to generate transcripts.
 
@@ -845,6 +848,7 @@ class AudioProcessor:
             word_timestamps (bool): When True, request word-level timestamps and write a
                 ``{base}_words.json`` sidecar per file so Align Features can reuse it instead
                 of re-transcribing later.
+            cancel_check (callable, optional): Return True to stop before the next file
         """
         if not audio_files:
             return
@@ -889,6 +893,8 @@ class AudioProcessor:
         
         transcription_errors = []
         for i, audio_file in enumerate(audio_files):
+            if cancel_check and cancel_check():
+                return
             self.set_status_message(f"🗣️ Transcribing ({i+1}/{total_files}): {os.path.basename(audio_file)}")
             
             try:
@@ -946,6 +952,8 @@ class AudioProcessor:
                 diarization_range = diarization_end - diarization_start
                 
                 for i, audio_file in enumerate(audio_files):
+                    if cancel_check and cancel_check():
+                        return
                     # Skip files that failed transcription
                     if transcription_results.get(audio_file, (None, None))[0] is None:
                         continue

--- a/src/audio.py
+++ b/src/audio.py
@@ -9,6 +9,7 @@ This module provides functionality for:
 """
 
 import os
+import json
 import torch
 import opensmile
 import gc
@@ -339,7 +340,8 @@ class AudioProcessor:
             model=self.whisper_model,
             tokenizer=self.whisper_processor.tokenizer,
             feature_extractor=self.whisper_processor.feature_extractor,
-            max_new_tokens=128,
+            # No max_new_tokens cap: a low cap (was 128) truncates long 30s chunks and
+            # breaks word-level timestamp alignment. Let Whisper use its full target window.
             chunk_length_s=30, # Standard chunk length for robustness
             batch_size=8,
             torch_dtype=self.torch_dtype,
@@ -830,16 +832,19 @@ class AudioProcessor:
             
         return "UNKNOWN"
 
-    def extract_transcripts_batch(self, audio_files, progress_callback=None):
+    def extract_transcripts_batch(self, audio_files, progress_callback=None, word_timestamps=False):
         """
         Batch process multiple audio files to generate transcripts.
-        
+
         OPTIMIZED: Loads each model once for all files instead of per-file,
         significantly reducing processing time for batches.
-        
+
         Args:
             audio_files (list): List of paths to WAV files
             progress_callback (callable, optional): Callback function for progress updates
+            word_timestamps (bool): When True, request word-level timestamps and write a
+                ``{base}_words.json`` sidecar per file so Align Features can reuse it instead
+                of re-transcribing later.
         """
         if not audio_files:
             return
@@ -890,8 +895,9 @@ class AudioProcessor:
                 audio_path = os.path.normpath(os.path.abspath(audio_file))
                 if not os.path.isfile(audio_path):
                     raise FileNotFoundError(f"Audio file not found: {audio_path}")
-                # Transcribe without loading/offloading model
-                ts_mode = True  # Use segment-level timestamps; word-level if needed for alignment
+                # Transcribe without loading/offloading model.
+                # word-level timestamps (for Align Features) when requested, else segment-level.
+                ts_mode = "word" if word_timestamps else True
                 result = self.whisper_pipe(
                     _whisper_pipeline_audio_input(audio_path),
                     return_timestamps=ts_mode,
@@ -999,6 +1005,17 @@ class AudioProcessor:
                 msg = f"{output_txt}: {e}"
                 print(f"Error saving transcript for {audio_file}: {e}")
                 save_errors.append(msg)
+
+            # When word-level timestamps were requested, write the JSON sidecar that
+            # Align Features consumes (so it won't have to re-transcribe this file).
+            if word_timestamps:
+                output_json = os.path.join(self.output_transcripts_folder, f"{base_name}_words.json")
+                try:
+                    with open(output_json, 'w', encoding='utf-8') as f:
+                        json.dump(whisper_result, f, indent=2, ensure_ascii=False)
+                    print(f"Saved word-level info: {output_json}")
+                except Exception as e:
+                    print(f"Warning: Could not save word-level JSON for {base_name}: {e}")
 
         if save_errors:
             raise RuntimeError(

--- a/src/gui_utils.py
+++ b/src/gui_utils.py
@@ -175,46 +175,174 @@ def create_transparent_text(parent, *args, **kwargs):
     else:
         return wx.StaticText(parent, *args, **kwargs)
 
-def style_checkbox_for_glass(checkbox):
-    """
-    Style a checkbox for use inside a GlassPanel on Windows.
-    On macOS, native transparency works fine so no changes needed.
-    On Windows, we set a dark background to approximate the glass panel color.
-    """
-    if sys.platform.startswith("win"):
-        # Use a dark color that approximates the glass panel's appearance
-        # The glass fill is (20, 20, 20, 100) alpha-blended over gradient
-        # A dark gray provides a reasonable approximation
-        dark_bg = wx.Colour(35, 50, 45)  # Dark teal-ish to blend with gradient
-        checkbox.SetBackgroundColour(dark_bg)
-
 class Theme:
-    # Colors
-    COLOR_BG_GRADIENT_START = '#00695C'  # Dark Teal
-    COLOR_BG_GRADIENT_END = '#2E7D32'    # Medium Forest Green
-    COLOR_TEXT_WHITE = '#FFFFFF'
+    # Background — desaturated deep teal → slate-green (recedes behind content)
+    COLOR_BG_GRADIENT_START = '#152826'  # slate-teal (top)
+    COLOR_BG_GRADIENT_END = '#1C2B22'    # slate-green (bottom)
+    COLOR_BG_GLOW = (46, 212, 122, 22)   # faint emerald ambient
+
+    # Surfaces — neutral charcoal with a faint green tint
+    COLOR_SURFACE = (32, 34, 32, 248)
+    COLOR_SURFACE_ELEVATED = (40, 42, 40, 252)
+    COLOR_GLASS_FILL = COLOR_SURFACE
+    COLOR_INPUT_BG = (24, 26, 24)
+    COLOR_GLASS_BORDER = (255, 255, 255, 16)
+    COLOR_SURFACE_BORDER = COLOR_GLASS_BORDER
+    COLOR_BORDER_HIGHLIGHT = (255, 255, 255, 40)
+
+    # Accent — vivid emerald reserved for primary CTA + focus rings
+    COLOR_PRIMARY = '#2ED47A'
+    COLOR_PRIMARY_HOVER = '#5CE09A'
+    COLOR_PRIMARY_PRESSED = '#22B869'
+    COLOR_PRIMARY_GLOW = (46, 212, 122, 90)
+    COLOR_SECONDARY = (255, 255, 255, 10)
+    COLOR_SECONDARY_HOVER = (255, 255, 255, 18)
+    COLOR_SECONDARY_PRESSED = (255, 255, 255, 6)
+    COLOR_SECONDARY_BORDER = (255, 255, 255, 28)
+    COLOR_BTN_DISABLED_FILL = (42, 44, 42)
+    COLOR_BTN_DISABLED_BORDER = (255, 255, 255, 12)
+    COLOR_DANGER = '#EF4444'
+    COLOR_DANGER_HOVER = '#F87171'
+    COLOR_DANGER_PRESSED = '#DC2626'
+
+    # Tabs — neutral track, emerald active pill
+    COLOR_TAB_TRACK = (18, 20, 18, 220)
+    COLOR_TAB_ACTIVE = (46, 212, 122, 255)
+    COLOR_TAB_ACTIVE_BORDER = (46, 212, 122, 140)
+
+    # Text
+    COLOR_TEXT_WHITE = '#F3F4F6'
     COLOR_TEXT_BLACK = '#000000'
-    COLOR_GLASS_FILL = (20, 20, 20, 100)
-    COLOR_GLASS_BORDER = (255, 255, 255, 40)
-    COLOR_ACCENT_GREEN = '#A5D6A7'
-    COLOR_PROGRESS_GREEN = (70, 180, 130)
-    COLOR_TOOLTIP_BG = '#1E1E1E'
-    COLOR_TOOLTIP_FG = '#F5F5F5'
-    COLOR_INFO_ICON_BG = '#666666'
-    
-    # Fonts
+    COLOR_TEXT_ON_DARK = '#FFFFFF'
+    COLOR_TEXT_MUTED = '#9CA3AF'
+    COLOR_TEXT_SUBTLE = '#6B7280'
+    COLOR_DISABLED = (107, 114, 128, 200)
+    COLOR_ACCENT_GREEN = '#2ED47A'
+    COLOR_FOCUS_RING = (46, 212, 122, 180)
+    # Secondary accent — reserved for help/info affordances only (not actions),
+    # so the "?" icons read as a distinct, discoverable category, not a CTA.
+    COLOR_ACCENT_INFO = '#38BDF8'        # sky/cyan
+    COLOR_ACCENT_INFO_SOFT = (56, 189, 248, 40)
+
+    # Progress
+    COLOR_PROGRESS_GREEN = (46, 212, 122)
+    COLOR_PROGRESS_FILL = COLOR_PROGRESS_GREEN
+    COLOR_PROGRESS_TRACK = (0, 0, 0, 70)
+    COLOR_PROGRESS_GLOW = (46, 212, 122, 50)
+
+    # Tooltips / chrome
+    COLOR_TOOLTIP_BG = '#1F2120'
+    COLOR_TOOLTIP_FG = '#E5E7EB'
+    COLOR_INFO_ICON_BG = (255, 255, 255, 14)
+    COLOR_INFO_ICON_BORDER = (255, 255, 255, 30)
+
+    # Spacing (logical px; use FromDIP in widgets)
+    SPACE_XS = 4
+    SPACE_SM = 8
+    SPACE_MD = 12
+    SPACE_LG = 16
+    SPACE_XL = 24
+    SPACE_XXL = 32
+
+    # Corner radii
+    RADIUS_BUTTON = 10
+    RADIUS_CARD = 14
+    RADIUS_TAB = 12
+    RADIUS_TAB_UNDERLINE = 3
+    RADIUS_INPUT = 8
+
+    # Font sizes (pt) — deliberate ramp for a clear, consistent hierarchy
+    FONT_DISPLAY = 32   # app name
+    FONT_TITLE = 17     # section/screen titles
+    FONT_BUTTON = 16    # action buttons
+    FONT_HEADING = 15   # primary settings labels
+    FONT_BODY = 14      # labels, inputs, status
+    FONT_SUBTITLE = 13  # header subtitle
+    FONT_CAPTION = 12   # secondary/status sublabels
+    FONT_OVERLINE = 11  # uppercase card eyebrow headings
+
+    # Legacy font constants
     FONT_FAMILY = wx.FONTFAMILY_SWISS
     FONT_STYLE_NORMAL = wx.FONTSTYLE_NORMAL
     FONT_WEIGHT_NORMAL = wx.FONTWEIGHT_NORMAL
     FONT_WEIGHT_BOLD = wx.FONTWEIGHT_BOLD
-    
+
     @staticmethod
     def get_font(size, bold=False):
         weight = Theme.FONT_WEIGHT_BOLD if bold else Theme.FONT_WEIGHT_NORMAL
         if sys.platform.startswith("win"):
-            # Use Segoe UI for a cleaner, modern Windows look
             return wx.Font(size, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, weight, False, "Segoe UI")
+        if sys.platform == "darwin":
+            return wx.Font(size, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, weight, False, "SF Pro Text")
         return wx.Font(size, Theme.FONT_FAMILY, Theme.FONT_STYLE_NORMAL, weight)
+
+    @staticmethod
+    def colour(hex_or_rgba):
+        """Return wx.Colour from '#RRGGBB' or (r, g, b[, a])."""
+        if isinstance(hex_or_rgba, str):
+            return wx.Colour(hex_or_rgba)
+        if len(hex_or_rgba) == 4:
+            return wx.Colour(hex_or_rgba[0], hex_or_rgba[1], hex_or_rgba[2], hex_or_rgba[3])
+        return wx.Colour(*hex_or_rgba)
+
+
+def style_native_input(ctrl):
+    """Theme native SpinCtrl / DirPicker for dark card surfaces."""
+    try:
+        ctrl.SetBackgroundColour(Theme.colour(Theme.COLOR_INPUT_BG))
+        ctrl.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_WHITE))
+    except Exception:
+        pass
+
+
+def composited_background_colour(window):
+    """Best-effort opaque colour of whatever is painted *behind* ``window``.
+
+    Owner-drawn controls (FlatButton, CustomCheckBox, ToggleTabBar, CustomGauge)
+    draw rounded shapes with translucent effects. On macOS the uncovered corners
+    show the parent through ``BG_STYLE_PAINT``; on Windows that style gives no real
+    transparency, so the corners/shadow band render against an uninitialised
+    background. Filling the client rect with this colour first removes that
+    divergence. Mirrors the gradient+glass sampling used by ``TransparentStaticText``.
+    """
+    try:
+        glass_fills = []
+        gradient = None
+        win = window.GetParent()
+        while win is not None:
+            # Only count glass panels that actually paint their fill (chrome=True).
+            fill = getattr(win, "fill_rgba", None)
+            if fill is not None and getattr(win, "chrome", True):
+                glass_fills.append(fill)
+            if hasattr(win, "CalcUnscrolledPosition") and hasattr(win, "GetVirtualSize"):
+                gradient = win
+                break
+            win = win.GetParent()
+
+        if gradient is None:
+            return wx.Colour(Theme.COLOR_BG_GRADIENT_START)
+
+        _fw, fh = gradient.GetVirtualSize()
+        fh = max(fh, 1)
+        child_screen = window.GetScreenPosition()
+        grad_screen = gradient.GetScreenPosition()
+        _sx, scroll_y = gradient.CalcUnscrolledPosition(0, 0)
+        rel_y = (child_screen.y - grad_screen.y) + scroll_y + window.GetSize().height / 2.0
+
+        # wx.NORTH gradient: END at top, START at bottom (see TransparentStaticText).
+        c_start = wx.Colour(Theme.COLOR_BG_GRADIENT_START)
+        c_end = wx.Colour(Theme.COLOR_BG_GRADIENT_END)
+        pct = max(0.0, min(1.0, rel_y / float(fh)))
+        base = _mix_colors(c_end, c_start, pct)
+
+        # Composite painting glass layers (farthest first, nearest last).
+        for fill in reversed(glass_fills):
+            rgb = wx.Colour(fill[0], fill[1], fill[2])
+            alpha = (fill[3] if len(fill) == 4 else 255) / 255.0
+            base = _mix_colors(base, rgb, alpha)
+        return base
+    except Exception:
+        return wx.Colour(Theme.COLOR_BG_GRADIENT_START)
 
 # --- Utility Functions ---
 

--- a/src/pose.py
+++ b/src/pose.py
@@ -398,8 +398,9 @@ class PoseProcessor:
                     self.status_callback(f"❌ Failed to load YOLOv5: {e}")
                 raise RuntimeError(f"Failed to initialize YOLOv5: {e}")
 
-    def extract_pose_features(self, video_path, progress_callback=None):
+    def extract_pose_features(self, video_path, progress_callback=None, cancel_check=None):
         """Extract pose features from video, saving one CSV per person."""
+        cancelled = False
         cap = cv2.VideoCapture(video_path)
         if not cap.isOpened():
             raise RuntimeError(
@@ -430,6 +431,9 @@ class PoseProcessor:
         locked_rois = []  # Each item: {"x1":int,"y1":int,"x2":int,"y2":int,"lost":int, "pose": Pose}
 
         while cap.isOpened():
+            if cancel_check and cancel_check():
+                cancelled = True
+                break
             ret, frame = cap.read()
             if not ret:
                 break
@@ -501,6 +505,9 @@ class PoseProcessor:
 
         # Cleanup ROI Pose instances to free resources (match embedding behavior)
         self._cleanup_locked_rois(locked_rois)
+
+        if cancelled:
+            return False
         
         
         # Define DataFrame column names
@@ -528,10 +535,11 @@ class PoseProcessor:
             csv_path = os.path.join(self.output_csv_folder, filename)
             df.to_csv(csv_path, index=False)
 
-        return
+        return True
 
-    def embed_pose_video(self, video_path, progress_callback=None):
+    def embed_pose_video(self, video_path, progress_callback=None, cancel_check=None):
         """Overlay pose landmarks on the video and save output."""
+        cancelled = False
         if not self.output_video_folder:
             return None
 
@@ -609,6 +617,9 @@ class PoseProcessor:
         last_single_landmarks = None  # mp_landmarks for single-person mode
 
         while cap.isOpened():
+            if cancel_check and cancel_check():
+                cancelled = True
+                break
             ret, frame = cap.read()
             if not ret:
                 break
@@ -742,4 +753,6 @@ class PoseProcessor:
         out.release()
         # Cleanup ROI Pose instances
         self._cleanup_locked_rois(locked_rois)
+        if cancelled:
+            return False
         return out_path

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -1,6 +1,15 @@
 import sys
 import wx
-from gui_utils import Theme, _mix_colors
+from gui_utils import Theme, _mix_colors, create_transparent_text, composited_background_colour
+
+
+def _fill_windows_background(window, dc):
+    """On Windows, fill the control's client rect with the colour painted behind
+    it so owner-drawn rounded corners / shadows don't show background artifacts.
+    No-op elsewhere (native BG_STYLE_PAINT transparency already works)."""
+    if sys.platform.startswith("win"):
+        dc.SetBackground(wx.Brush(composited_background_colour(window)))
+        dc.Clear()
 
 class GradientPanel(wx.ScrolledWindow):
     def __init__(self, parent):
@@ -12,16 +21,23 @@ class GradientPanel(wx.ScrolledWindow):
     def OnPaint(self, event):
         dc = wx.AutoBufferedPaintDC(self)
         self.DoPrepareDC(dc)
-        # Use virtual size to fill the entire scrollable area, not just client rect
-        # However, for a simple gradient background that stays fixed or stretches, 
-        # we need to be careful. If we want the gradient to scroll WITH content, we allow it.
-        # If we want fixed background, it's harder with ScrolledWindow.
-        # Let's assume scrolling the gradient is fine or even preferred so it covers everything.
-        
-        # Get the full virtual size to ensure gradient covers all scrolled content
         width, height = self.GetVirtualSize()
         rect = wx.Rect(0, 0, width, height)
         dc.GradientFillLinear(rect, Theme.COLOR_BG_GRADIENT_START, Theme.COLOR_BG_GRADIENT_END, wx.NORTH)
+
+        gc = wx.GraphicsContext.Create(dc)
+        if gc and width > 0 and height > 0:
+            glow = Theme.COLOR_BG_GLOW
+            cx, cy = width / 2.0, height * 0.12
+            radius = max(width, height) * 0.55
+            brush = gc.CreateRadialGradientBrush(
+                cx, cy, cx, cy, radius,
+                wx.Colour(glow[0], glow[1], glow[2], glow[3]),
+                wx.Colour(glow[0], glow[1], glow[2], 0),
+            )
+            gc.SetBrush(brush)
+            gc.SetPen(wx.TRANSPARENT_PEN)
+            gc.DrawRectangle(0, 0, width, height)
 
 
 class GlassPanel(wx.Panel):
@@ -29,11 +45,12 @@ class GlassPanel(wx.Panel):
 
     Children should be added to its internal BoxSizer via SetSizer as usual.
     """
-    def __init__(self, parent, corner_radius=10, fill_rgba=Theme.COLOR_GLASS_FILL):
+    def __init__(self, parent, corner_radius=10, fill_rgba=Theme.COLOR_GLASS_FILL, chrome=True):
         super(GlassPanel, self).__init__(parent, style=wx.BORDER_NONE)
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
         self.corner_radius = corner_radius
         self.fill_rgba = fill_rgba
+        self.chrome = chrome
         self.Bind(wx.EVT_PAINT, self.OnPaint)
 
     def _paint_gradient_background_windows(self, dc, rect):
@@ -88,12 +105,13 @@ class GlassPanel(wx.Panel):
         if not gc:
             return
         
-        # Windows-specific: Paint gradient background first to avoid gray showing through
         if sys.platform.startswith("win"):
             self._paint_gradient_background_windows(dc, rect)
-        
-        # Inset so the rounded border isn't clipped
-        inset = 6
+
+        if not self.chrome:
+            return
+
+        inset = self.FromDIP(4)
         x = rect.x + inset
         y = rect.y + inset
         w = max(0, rect.width - inset * 2)
@@ -105,6 +123,17 @@ class GlassPanel(wx.Panel):
         gc.SetBrush(wx.Brush(rcol))
         gc.SetPen(wx.Pen(wx.Colour(*Theme.COLOR_GLASS_BORDER), 1))
         gc.DrawPath(path)
+
+        # Subtle full-height top sheen that fades to nothing (no hard mid-card edge).
+        sheen = gc.CreatePath()
+        sheen.AddRoundedRectangle(x, y, w, h, r)
+        gc.SetBrush(gc.CreateLinearGradientBrush(
+            x, y, x, y + h,
+            wx.Colour(255, 255, 255, 14),
+            wx.Colour(255, 255, 255, 0),
+        ))
+        gc.SetPen(wx.TRANSPARENT_PEN)
+        gc.DrawPath(sheen)
 
 
 class ElevatedLogoPanel(wx.Panel):
@@ -202,20 +231,21 @@ class ElevatedLogoPanel(wx.Panel):
         # Subtle shadow (fake blur via semi-transparent larger ellipse)
         gc = wx.GraphicsContext.Create(dc)
         if gc:
-            shadow_color = wx.Colour(0, 0, 0, 60)  # low alpha for soft shadow
+            shadow_color = wx.Colour(0, 0, 0, 70)
             gc.SetBrush(wx.Brush(shadow_color))
             gc.SetPen(wx.Pen(shadow_color, 1))
-            gc.DrawEllipse(x + 3, y + 4, diameter, diameter)  # slight offset
+            gc.DrawEllipse(x + 2, y + 5, diameter, diameter)
 
-        # Prepare circular bitmap and draw
         circ_bmp = self._create_circular_bitmap(self.logo_bitmap, diameter)
         dc.DrawBitmap(circ_bmp, x, y, True)
 
-        # Black circular border
         if gc:
             gc.SetBrush(wx.TRANSPARENT_BRUSH)
-            gc.SetPen(wx.Pen(wx.Colour(0, 0, 0), 3))
+            ring = Theme.colour(Theme.COLOR_ACCENT_GREEN)
+            gc.SetPen(wx.Pen(ring, 2))
             gc.DrawEllipse(x, y, diameter, diameter)
+            gc.SetPen(wx.Pen(wx.Colour(255, 255, 255, 40), 1))
+            gc.DrawEllipse(x + 2, y + 2, diameter - 4, diameter - 4)
 
     def OnMouseEnter(self, event):
         self.hover = True
@@ -243,10 +273,10 @@ class CustomTooltip(wx.PopupWindow):
         # Create a panel for the tooltip content
         panel = wx.Panel(self)
         panel.SetBackgroundColour(Theme.COLOR_TOOLTIP_BG)
+        self.content_panel = panel
         
-        # Create text control for the tooltip with word wrapping
         self.text_ctrl = wx.StaticText(panel, label=text, style=wx.ALIGN_LEFT)
-        self.text_ctrl.SetFont(Theme.get_font(11, bold=False))
+        self.text_ctrl.SetFont(Theme.get_font(Theme.FONT_CAPTION, bold=False))
         self.text_ctrl.SetForegroundColour(Theme.COLOR_TOOLTIP_FG)
         self.text_ctrl.Wrap(340)
         
@@ -263,94 +293,132 @@ class CustomTooltip(wx.PopupWindow):
 
 class InfoIcon(wx.StaticText):
     def __init__(self, parent, tooltip_text):
-        super(InfoIcon, self).__init__(parent, label="ℹ", style=wx.ALIGN_CENTER)
+        super(InfoIcon, self).__init__(parent, label="?", style=wx.ALIGN_CENTER)
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
         self.tooltip_text = tooltip_text
         self.tooltip = None
+        self._hide_timer = None
         self._top_level = self.GetTopLevelParent()
         
-        # Style the info icon
-        self.SetFont(Theme.get_font(12, bold=True))
-        self.SetForegroundColour(Theme.COLOR_TEXT_WHITE)
-        self.SetBackgroundColour(Theme.COLOR_INFO_ICON_BG)
-        self.SetMinSize(self.FromDIP(wx.Size(20, 20)))
+        self.SetFont(Theme.get_font(Theme.FONT_CAPTION, bold=True))
+        self.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_MUTED))
+        self.SetMinSize(self.FromDIP(wx.Size(24, 24)))
         
-        # Bind mouse events
         self.Bind(wx.EVT_ENTER_WINDOW, self.OnMouseEnter)
         self.Bind(wx.EVT_LEAVE_WINDOW, self.OnMouseLeave)
-        self.Bind(wx.EVT_MOTION, self.OnMouseMove)
         self.Bind(wx.EVT_PAINT, self.OnPaint)
-        # Hide tooltip when the window moves/resizes to avoid misplacement
         if self._top_level:
             self._top_level.Bind(wx.EVT_MOVE, self._on_parent_move_or_resize)
             self._top_level.Bind(wx.EVT_SIZE, self._on_parent_move_or_resize)
-        # Cleanup bindings on destroy
         self.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
     
     def OnPaint(self, event):
         dc = wx.AutoBufferedPaintDC(self)
+        gc = wx.GraphicsContext.Create(dc)
+        if not gc:
+            return
         rect = self.GetClientRect()
-        
-        # Draw circular background
-        dc.SetBrush(wx.Brush(Theme.COLOR_INFO_ICON_BG))
-        dc.SetPen(wx.Pen(Theme.COLOR_INFO_ICON_BG, 1))
-        dc.DrawCircle(rect.width//2, rect.height//2, min(rect.width, rect.height)//2 - 1)
-        
-        # Draw the "i" text
-        dc.SetTextForeground(Theme.COLOR_TEXT_WHITE)
-        dc.SetFont(self.GetFont())
-        text_width, text_height = dc.GetTextExtent("ℹ")
-        dc.DrawText("ℹ", (rect.width - text_width)//2, (rect.height - text_height)//2)
+        cx = rect.width / 2.0
+        cy = rect.height / 2.0
+        radius = min(rect.width, rect.height) / 2.0 - 1
+
+        hovered = getattr(self, "_hover", False)
+        if hovered:
+            fill = Theme.colour(Theme.COLOR_ACCENT_INFO_SOFT)
+            border = Theme.colour(Theme.COLOR_ACCENT_INFO)
+            glyph = Theme.colour(Theme.COLOR_ACCENT_INFO)
+        else:
+            fill = Theme.colour(Theme.COLOR_INFO_ICON_BG)
+            border = Theme.colour(Theme.COLOR_INFO_ICON_BORDER)
+            glyph = Theme.colour(Theme.COLOR_TEXT_MUTED)
+
+        gc.SetBrush(wx.Brush(fill))
+        gc.SetPen(wx.Pen(border, 1))
+        gc.DrawEllipse(cx - radius, cy - radius, radius * 2, radius * 2)
+
+        gc.SetFont(self.GetFont(), glyph)
+        label = "?"
+        tw, th = gc.GetTextExtent(label)
+        gc.DrawText(label, cx - tw / 2.0, cy - th / 2.0)
     
     def OnMouseEnter(self, event):
+        self._hover = True
+        self.Refresh()
+        self._cancel_hide()
         if not self.tooltip:
             self.tooltip = CustomTooltip(self.GetParent(), self.tooltip_text)
-            self.ShowTooltip()
+            self._bind_tooltip_hover()
+        self.ShowTooltip()
         event.Skip()
-    
+
     def OnMouseLeave(self, event):
-        if self.tooltip:
-            self.tooltip.Destroy()
-            self.tooltip = None
+        self._hover = False
+        self.Refresh()
+        self._schedule_hide()
         event.Skip()
     
-    def OnMouseMove(self, event):
-        if self.tooltip:
-            self.ShowTooltip()
+    def _bind_tooltip_hover(self):
+        if not self.tooltip:
+            return
+        for win in (self.tooltip, getattr(self.tooltip, "content_panel", None), getattr(self.tooltip, "text_ctrl", None)):
+            if win:
+                win.Bind(wx.EVT_ENTER_WINDOW, self._on_tooltip_enter)
+                win.Bind(wx.EVT_LEAVE_WINDOW, self._on_tooltip_leave)
+
+    def _on_tooltip_enter(self, event):
+        self._cancel_hide()
         event.Skip()
+
+    def _on_tooltip_leave(self, event):
+        self._schedule_hide()
+        event.Skip()
+
+    def _cancel_hide(self):
+        if self._hide_timer and self._hide_timer.IsRunning():
+            self._hide_timer.Stop()
+
+    def _schedule_hide(self):
+        self._cancel_hide()
+        self._hide_timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self._on_hide_timer, self._hide_timer)
+        self._hide_timer.Start(150, oneShot=True)
+
+    def _on_hide_timer(self, event):
+        self._destroy_tooltip()
+
+    def _destroy_tooltip(self):
+        if self.tooltip:
+            try:
+                self.tooltip.Destroy()
+            except Exception:
+                pass
+            self.tooltip = None
     
     def ShowTooltip(self):
-        if self.tooltip:
-            # Get the screen position of the icon
-            icon_rect = self.GetRect()
-            parent_pos = self.GetParent().GetScreenPosition()
-            
-            # Calculate tooltip position to the right of the icon
-            tooltip_x = parent_pos.x + icon_rect.x + icon_rect.width + 2
-            tooltip_y = parent_pos.y + icon_rect.y
-            
-            # Clamp within visible display bounds to avoid overflow
-            try:
-                screen_w, screen_h = wx.GetDisplaySize()
-                tip_w, tip_h = self.tooltip.GetSize()
-                tooltip_x = max(0, min(tooltip_x, screen_w - tip_w - 8))
-                tooltip_y = max(0, min(tooltip_y, screen_h - tip_h - 8))
-            except Exception:
-                pass
-            
-            self.tooltip.Position((tooltip_x, tooltip_y), (0, 0))
-            self.tooltip.Show()
+        if not self.tooltip:
+            return
+        icon_rect = self.GetRect()
+        parent_pos = self.GetParent().GetScreenPosition()
+        tooltip_x = parent_pos.x + icon_rect.x
+        tooltip_y = parent_pos.y + icon_rect.y + icon_rect.height + self.FromDIP(6)
+        try:
+            screen_w, screen_h = wx.GetDisplaySize()
+            tip_w, tip_h = self.tooltip.GetSize()
+            tooltip_x = max(0, min(tooltip_x, screen_w - tip_w - 8))
+            tooltip_y = max(0, min(tooltip_y, screen_h - tip_h - 8))
+        except Exception:
+            pass
+        self.tooltip.Position((tooltip_x, tooltip_y), (0, 0))
+        self.tooltip.Show()
+        self.tooltip.Raise()
 
     def _on_parent_move_or_resize(self, event):
-        if self.tooltip:
-            try:
-                self.tooltip.Hide()
-            except Exception:
-                pass
+        self._destroy_tooltip()
         event.Skip()
 
     def _on_destroy(self, event):
-        # Unbind move/size handlers when this icon is destroyed
+        self._destroy_tooltip()
+        self._cancel_hide()
         try:
             if self._top_level:
                 self._top_level.Unbind(wx.EVT_MOVE, handler=self._on_parent_move_or_resize)
@@ -360,50 +428,477 @@ class InfoIcon(wx.StaticText):
         event.Skip()
 
 
-class TooltipButton(wx.Button):
-    def __init__(self, parent, label, tooltip_text):
-        super(TooltipButton, self).__init__(parent, label=label)
-        self.tooltip_text = tooltip_text
-        self.info_icon = None
-        
-    def add_info_icon(self, parent):
-        """Add info icon to the button's parent container"""
-        self.info_icon = InfoIcon(parent, self.tooltip_text)
-        return self.info_icon
-    
+class FlatButton(wx.Window):
+    """Owner-drawn rounded button (primary / secondary / danger)."""
+
+    VARIANT_PRIMARY = "primary"
+    VARIANT_SECONDARY = "secondary"
+    VARIANT_DANGER = "danger"
+
+    _VARIANT_COLORS = {
+        VARIANT_PRIMARY: (
+            Theme.COLOR_PRIMARY,
+            Theme.COLOR_PRIMARY_HOVER,
+            Theme.COLOR_PRIMARY_PRESSED,
+        ),
+        VARIANT_SECONDARY: (
+            Theme.COLOR_SECONDARY,
+            Theme.COLOR_SECONDARY_HOVER,
+            Theme.COLOR_SECONDARY_PRESSED,
+        ),
+        VARIANT_DANGER: (
+            Theme.COLOR_DANGER,
+            Theme.COLOR_DANGER_HOVER,
+            Theme.COLOR_DANGER_PRESSED,
+        ),
+    }
+
+    def __init__(self, parent, label="", variant=VARIANT_PRIMARY, id=wx.ID_ANY, size=(-1, -1)):
+        super(FlatButton, self).__init__(parent, id=id, size=size, style=wx.BORDER_NONE)
+        self._label = label
+        self._variant = variant if variant in self._VARIANT_COLORS else self.VARIANT_PRIMARY
+        self._hover = False
+        self._pressed = False
+        self._font = Theme.get_font(Theme.FONT_BUTTON)
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+        self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_ENTER_WINDOW, self._on_enter)
+        self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
+        self.Bind(wx.EVT_LEFT_DOWN, self._on_down)
+        self.Bind(wx.EVT_LEFT_UP, self._on_up)
+        self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._on_capture_lost)
+        self._update_min_size()
+
+    def _update_min_size(self):
+        dc = wx.ClientDC(self)
+        dc.SetFont(self._font)
+        tw, th = dc.GetTextExtent(self._label)
+        pad_x = self.FromDIP(Theme.SPACE_LG * 2)
+        pad_y = self.FromDIP(Theme.SPACE_SM + 4)
+        self.SetMinSize((tw + pad_x, th + pad_y))
+
+    def Enable(self, enable=True):
+        result = super(FlatButton, self).Enable(enable)
+        self.Refresh()
+        return result
+
+    def SetLabel(self, label):
+        self._label = label
+        self._update_min_size()
+        self.Refresh()
+
+    def GetLabel(self):
+        return self._label
+
+    def SetFont(self, font):
+        self._font = font
+        self._update_min_size()
+        self.Refresh()
+
+    def _fill_colour(self):
+        if not self.IsEnabled():
+            return Theme.colour(Theme.COLOR_BTN_DISABLED_FILL)
+        normal, hover, pressed = self._VARIANT_COLORS[self._variant]
+        if self._pressed:
+            return Theme.colour(pressed)
+        if self._hover:
+            return Theme.colour(hover)
+        return Theme.colour(normal)
+
+    def _on_paint(self, event):
+        dc = wx.AutoBufferedPaintDC(self)
+        _fill_windows_background(self, dc)
+        gc = wx.GraphicsContext.Create(dc)
+        if not gc:
+            return
+        rect = self.GetClientRect()
+        radius = self.FromDIP(Theme.RADIUS_BUTTON)
+        is_secondary = self._variant == self.VARIANT_SECONDARY
+        enabled = self.IsEnabled()
+
+        if enabled and not self._pressed:
+            shadow = gc.CreatePath()
+            shadow.AddRoundedRectangle(rect.x, rect.y + 2, rect.width, rect.height, radius)
+            gc.SetBrush(wx.Brush(wx.Colour(0, 0, 0, 55)))
+            gc.SetPen(wx.TRANSPARENT_PEN)
+            gc.DrawPath(shadow)
+
+        path = gc.CreatePath()
+        path.AddRoundedRectangle(rect.x, rect.y, rect.width, rect.height, radius)
+        gc.SetBrush(wx.Brush(self._fill_colour()))
+        if not enabled:
+            gc.SetPen(wx.Pen(Theme.colour(Theme.COLOR_BTN_DISABLED_BORDER), 1))
+        elif is_secondary:
+            gc.SetPen(wx.Pen(Theme.colour(Theme.COLOR_SECONDARY_BORDER), 1))
+        else:
+            gc.SetPen(wx.Pen(wx.Colour(0, 0, 0, 0)))
+        gc.DrawPath(path)
+
+        # No shine on primary: keep it flat so the CTA green reads identical to the
+        # active tab pill (same COLOR_PRIMARY). The drop shadow alone gives depth.
+
+        if not enabled:
+            text_colour = Theme.colour(Theme.COLOR_TEXT_SUBTLE)
+        else:
+            text_colour = Theme.colour(Theme.COLOR_TEXT_ON_DARK)
+        gc.SetFont(self._font, text_colour)
+        tw, th = gc.GetTextExtent(self._label)
+        gc.DrawText(
+            self._label,
+            rect.x + (rect.width - tw) / 2.0,
+            rect.y + (rect.height - th) / 2.0,
+        )
+
+    def _on_enter(self, event):
+        if self.IsEnabled():
+            self._hover = True
+            self.SetCursor(wx.Cursor(wx.CURSOR_HAND))
+            self.Refresh()
+        event.Skip()
+
+    def _on_leave(self, event):
+        # Leave hover state, but keep _pressed/capture intact while the button is
+        # held: _on_up (or capture-lost) is the only place that releases capture,
+        # so clearing _pressed here would leak the mouse capture and freeze input.
+        self._hover = False
+        self.SetCursor(wx.Cursor(wx.CURSOR_ARROW))
+        self.Refresh()
+        event.Skip()
+
+    def _on_down(self, event):
+        if self.IsEnabled():
+            self._pressed = True
+            self.CaptureMouse()
+            self.Refresh()
+        event.Skip()
+
+    def _on_up(self, event):
+        was_pressed = self._pressed
+        self._pressed = False
+        if self.HasCapture():
+            self.ReleaseMouse()
+        self.Refresh()
+        if was_pressed and self.IsEnabled() and self.GetClientRect().Contains(event.GetPosition()):
+            evt = wx.CommandEvent(wx.EVT_BUTTON.typeId, self.GetId())
+            evt.SetEventObject(self)
+            self.GetEventHandler().ProcessEvent(evt)
+        event.Skip()
+
+    def _on_capture_lost(self, event):
+        # Required whenever CaptureMouse() is used: if the capture is stolen
+        # (e.g. a modal dialog opens), reset state instead of asserting.
+        self._pressed = False
+        self.Refresh()
+
+
+class _TabFontProxy:
+    """Allows font-scaling registry to target segmented tab labels."""
+
+    def __init__(self, bar):
+        self._bar = bar
+
+    def SetFont(self, font):
+        self._bar._tab_font = font
+        self._bar.Refresh()
+
+
+class ToggleTabBar(wx.Panel):
+    """Segmented Video / Audio mode control."""
+
+    _SEGMENTS = (("video", "Video"), ("audio", "Audio"))
+
+    def __init__(self, parent):
+        super(ToggleTabBar, self).__init__(parent, style=wx.BORDER_NONE)
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+        self._selected = "video"
+        self._tabs_enabled = True
+        self._on_change = None
+        self._tab_font = Theme.get_font(Theme.FONT_BODY, bold=True)
+        self._hover_segment = None
+
+        self.video_tab = _TabFontProxy(self)
+        self.audio_tab = _TabFontProxy(self)
+
+        tab_h = self.FromDIP(50)
+        self.SetMinSize((-1, tab_h))
+        self.SetMaxSize((-1, tab_h))
+        self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_LEFT_DOWN, self._on_click)
+        self.Bind(wx.EVT_MOTION, self._on_motion)
+        self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
+
+    def set_on_change(self, callback):
+        self._on_change = callback
+
+    def set_selected(self, mode):
+        self._select(mode, fire=False)
+
+    def get_selected(self):
+        return self._selected
+
+    def EnableTabs(self, enable=True):
+        self._tabs_enabled = enable
+        self.Refresh()
+
+    def _segment_at(self, x):
+        rect = self.GetClientRect()
+        pad = self.FromDIP(Theme.SPACE_XS)
+        track_w = max(1, rect.width - pad * 2)
+        local_x = x - pad
+        if local_x < track_w / 2.0:
+            return "video"
+        return "audio"
+
+    def _select(self, mode, fire=False):
+        if not self._tabs_enabled and fire:
+            return
+        if mode not in ("video", "audio"):
+            return
+        self._selected = mode
+        self.Refresh()
+        if fire and self._on_change:
+            self._on_change(mode)
+
+    def _on_click(self, event):
+        if not self._tabs_enabled:
+            return
+        self._select(self._segment_at(event.GetX()), fire=True)
+
+    def _on_motion(self, event):
+        if not self._tabs_enabled:
+            self._hover_segment = None
+            return
+        seg = self._segment_at(event.GetX())
+        if seg != self._hover_segment:
+            self._hover_segment = seg
+            self.SetCursor(wx.Cursor(wx.CURSOR_HAND))
+            self.Refresh()
+
+    def _on_leave(self, event):
+        self._hover_segment = None
+        self.SetCursor(wx.Cursor(wx.CURSOR_ARROW))
+        self.Refresh()
+        event.Skip()
+
+    def _on_paint(self, event):
+        dc = wx.AutoBufferedPaintDC(self)
+        _fill_windows_background(self, dc)
+        gc = wx.GraphicsContext.Create(dc)
+        if not gc:
+            return
+
+        rect = self.GetClientRect()
+        pad = self.FromDIP(Theme.SPACE_XS)
+        track = wx.Rect(pad, pad, rect.width - pad * 2, rect.height - pad * 2)
+        radius = self.FromDIP(Theme.RADIUS_TAB)
+
+        # Opaque track so tabs never disappear under siblings on any platform
+        track_path = gc.CreatePath()
+        track_path.AddRoundedRectangle(track.x, track.y, track.width, track.height, radius)
+        gc.SetBrush(wx.Brush(Theme.colour(Theme.COLOR_TAB_TRACK)))
+        gc.SetPen(wx.Pen(wx.Colour(255, 255, 255, 20), 1))
+        gc.DrawPath(track_path)
+
+        seg_w = track.width / 2.0
+        for idx, (mode, _label) in enumerate(self._SEGMENTS):
+            if mode != self._selected:
+                continue
+            pill_x = track.x + idx * seg_w + self.FromDIP(3)
+            pill_y = track.y + self.FromDIP(3)
+            pill_w = seg_w - self.FromDIP(6)
+            pill_h = track.height - self.FromDIP(6)
+            pill_path = gc.CreatePath()
+            pill_path.AddRoundedRectangle(pill_x, pill_y, pill_w, pill_h, radius - 2)
+            gc.SetBrush(wx.Brush(Theme.colour(Theme.COLOR_TAB_ACTIVE)))
+            gc.SetPen(wx.Pen(Theme.colour(Theme.COLOR_TAB_ACTIVE_BORDER), 1))
+            gc.DrawPath(pill_path)
+
+        font = self._tab_font
+        for idx, (mode, label) in enumerate(self._SEGMENTS):
+            if not self._tabs_enabled:
+                colour = Theme.colour(Theme.COLOR_DISABLED)
+            elif mode == self._selected:
+                colour = Theme.colour(Theme.COLOR_TEXT_BLACK)
+            elif mode == self._hover_segment:
+                colour = Theme.colour(Theme.COLOR_ACCENT_GREEN)
+            else:
+                colour = Theme.colour(Theme.COLOR_TEXT_MUTED)
+            gc.SetFont(font, colour)
+            tw, th = gc.GetTextExtent(label)
+            cx = track.x + seg_w * idx + seg_w / 2.0
+            cy = track.y + track.height / 2.0
+            gc.DrawText(label, cx - tw / 2.0, cy - th / 2.0)
+
+
+class CustomCheckBox(wx.Window):
+    """Owner-drawn checkbox with label."""
+
+    def __init__(self, parent, label="", id=wx.ID_ANY):
+        super(CustomCheckBox, self).__init__(parent, id=id, style=wx.BORDER_NONE)
+        self._label = label
+        self._value = False
+        self._hover = False
+        self._font = Theme.get_font(Theme.FONT_BODY)
+        self._text_colour = Theme.colour(Theme.COLOR_TEXT_WHITE)
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+        self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_LEFT_DOWN, self._on_click)
+        self.Bind(wx.EVT_ENTER_WINDOW, self._on_enter)
+        self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
+        self._update_min_size()
+
+    def _box_size(self):
+        return self.FromDIP(18)
+
+    def _update_min_size(self):
+        dc = wx.ClientDC(self)
+        dc.SetFont(self._font)
+        tw, th = dc.GetTextExtent(self._label)
+        box = self._box_size()
+        gap = self.FromDIP(Theme.SPACE_SM)
+        self.SetMinSize((box + gap + tw, max(box, th) + self.FromDIP(Theme.SPACE_XS)))
+
+    def GetValue(self):
+        return self._value
+
+    def SetValue(self, value):
+        self._value = bool(value)
+        self.Refresh()
+
+    def SetLabel(self, label):
+        self._label = label
+        self._update_min_size()
+        self.Refresh()
+
+    def GetLabel(self):
+        return self._label
+
+    def SetFont(self, font):
+        self._font = font
+        self._update_min_size()
+        self.Refresh()
+
+    def SetForegroundColour(self, colour):
+        self._text_colour = colour
+        self.Refresh()
+
+    def Enable(self, enable=True):
+        result = super(CustomCheckBox, self).Enable(enable)
+        self.Refresh()
+        return result
+
+    def _on_paint(self, event):
+        dc = wx.AutoBufferedPaintDC(self)
+        _fill_windows_background(self, dc)
+        gc = wx.GraphicsContext.Create(dc)
+        if not gc:
+            return
+        rect = self.GetClientRect()
+        box = self._box_size()
+        by = rect.y + (rect.height - box) / 2.0
+        bx = rect.x
+        gap = self.FromDIP(Theme.SPACE_SM)
+
+        if self._hover and self.IsEnabled():
+            row_path = gc.CreatePath()
+            row_path.AddRoundedRectangle(rect.x - 4, rect.y, rect.width + 8, rect.height, self.FromDIP(6))
+            gc.SetBrush(wx.Brush(wx.Colour(255, 255, 255, 12)))
+            gc.SetPen(wx.TRANSPARENT_PEN)
+            gc.DrawPath(row_path)
+
+        enabled = self.IsEnabled()
+        radius = self.FromDIP(5)
+        path = gc.CreatePath()
+        path.AddRoundedRectangle(bx, by, box, box, radius)
+        if self._value and enabled:
+            gc.SetBrush(wx.Brush(Theme.colour(Theme.COLOR_PRIMARY)))
+            gc.SetPen(wx.Pen(Theme.colour(Theme.COLOR_PRIMARY_HOVER), 1))
+        else:
+            gc.SetBrush(wx.Brush(Theme.colour(Theme.COLOR_BTN_DISABLED_FILL if not enabled else Theme.COLOR_INPUT_BG)))
+            gc.SetPen(wx.Pen(Theme.colour(Theme.COLOR_BTN_DISABLED_BORDER if not enabled else Theme.COLOR_SECONDARY_BORDER), 1))
+        gc.DrawPath(path)
+        if self._value and enabled:
+            gc.SetPen(wx.Pen(Theme.colour(Theme.COLOR_TEXT_ON_DARK), 2))
+            cx, cy = bx + box / 2.0, by + box / 2.0
+            gc.StrokeLine(cx - box * 0.2, cy, cx - box * 0.05, cy + box * 0.18)
+            gc.StrokeLine(cx - box * 0.05, cy + box * 0.18, cx + box * 0.22, cy - box * 0.15)
+        label_colour = self._text_colour if enabled else Theme.colour(Theme.COLOR_TEXT_SUBTLE)
+        gc.SetFont(self._font, label_colour)
+        tw, th = gc.GetTextExtent(self._label)
+        gc.DrawText(self._label, bx + box + gap, rect.y + (rect.height - th) / 2.0)
+
+    def _on_click(self, event):
+        if not self.IsEnabled():
+            return
+        self._value = not self._value
+        self.Refresh()
+        evt = wx.CommandEvent(wx.EVT_CHECKBOX.typeId, self.GetId())
+        evt.SetInt(int(self._value))
+        evt.SetEventObject(self)
+        self.GetEventHandler().ProcessEvent(evt)
+
+    def _on_enter(self, event):
+        self._hover = True
+        self.SetCursor(wx.Cursor(wx.CURSOR_HAND))
+        event.Skip()
+
+    def _on_leave(self, event):
+        self._hover = False
+        self.SetCursor(wx.Cursor(wx.CURSOR_ARROW))
+        self.Refresh()
+        event.Skip()
+
+
+class SectionCard(GlassPanel):
+    """Glass card with optional heading and standardized padding."""
+
+    def __init__(self, parent, heading=None, corner_radius=Theme.RADIUS_CARD, fill_rgba=Theme.COLOR_SURFACE_ELEVATED):
+        super(SectionCard, self).__init__(parent, corner_radius=corner_radius, fill_rgba=fill_rgba)
+        outer = wx.BoxSizer(wx.VERTICAL)
+        pad = Theme.SPACE_LG
+        if heading:
+            heading_label = create_transparent_text(self, label=heading.upper(), style=wx.ALIGN_LEFT)
+            heading_label.SetFont(Theme.get_font(Theme.FONT_OVERLINE, bold=True))
+            heading_label.SetForegroundColour(Theme.colour(Theme.COLOR_TEXT_MUTED))
+            outer.Add(heading_label, flag=wx.LEFT | wx.RIGHT | wx.TOP, border=pad)
+            divider = wx.Panel(self, size=(-1, 1))
+            divider.SetBackgroundColour(Theme.colour(Theme.COLOR_GLASS_BORDER))
+            outer.Add(divider, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border=Theme.SPACE_SM)
+            self._heading_label = heading_label
+        else:
+            self._heading_label = None
+        self.content_sizer = wx.BoxSizer(wx.VERTICAL)
+        outer.Add(self.content_sizer, proportion=1, flag=wx.EXPAND | wx.ALL, border=pad)
+        self.SetSizer(outer)
+
+
+class TooltipButton:
+    """Factory for FlatButton + InfoIcon action rows."""
+
     @staticmethod
-    def create_with_icon(parent, label, tooltip_text, font=None, handler=None):
-        """Factory method to create a button and its info icon in a horizontal sizer."""
+    def create_with_icon(parent, label, tooltip_text, font=None, handler=None, variant=FlatButton.VARIANT_PRIMARY):
         sizer = wx.BoxSizer(wx.HORIZONTAL)
-        
-        btn = TooltipButton(parent, label, tooltip_text)
+        btn = FlatButton(parent, label=label, variant=variant)
         if font:
             btn.SetFont(font)
         if handler:
             btn.Bind(wx.EVT_BUTTON, handler)
-            
-        sizer.Add(btn, flag=wx.ALIGN_CENTER|wx.ALL, border=12)
-        
-        info_icon = btn.add_info_icon(parent)
-        sizer.Add(info_icon, flag=wx.ALIGN_CENTER|wx.LEFT, border=5)
-        
+        sizer.Add(btn, proportion=1, flag=wx.EXPAND | wx.ALL, border=Theme.SPACE_SM)
+        info_icon = InfoIcon(parent, tooltip_text)
+        sizer.Add(info_icon, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, border=Theme.SPACE_SM)
         return btn, sizer
 
 class CustomGauge(wx.Panel):
     """A custom-drawn gauge that respects height on macOS and Windows."""
-    def __init__(self, parent, range=100, size=(-1, 28)):
-        # Add wx.NO_BORDER and wx.NO_FULL_REPAINT_ON_RESIZE to prevent Windows artifacts
+    def __init__(self, parent, range=100, size=(-1, 32)):
         super(CustomGauge, self).__init__(parent, size=size, style=wx.NO_BORDER | wx.NO_FULL_REPAINT_ON_RESIZE)
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
         self._range = range
         self._value = 0
-        # Default colors
-        self._bg_color = wx.Colour(40, 40, 40, 100)  # Dark semi-transparent background
-        self._fg_color = wx.Colour(33, 150, 243)  # Blue
-        
-        # Windows-specific: disable focus indicators and set background
+        self._bg_color = Theme.colour(Theme.COLOR_PROGRESS_TRACK)
+        self._fg_color = Theme.colour(Theme.COLOR_PROGRESS_FILL)
+
         if wx.Platform == '__WXMSW__':
-            self.SetBackgroundColour(wx.Colour(30, 60, 40))  # Match gradient
             self.SetDoubleBuffered(True)
         
         self.Bind(wx.EVT_PAINT, self.OnPaint)
@@ -443,64 +938,41 @@ class CustomGauge(wx.Panel):
     def OnPaint(self, event):
         # Use AutoBufferedPaintDC for cross-platform consistency (prevents flicker on Windows)
         dc = wx.AutoBufferedPaintDC(self)
-        
-        # Clear background on Windows to prevent artifacts
-        if wx.Platform == '__WXMSW__':
-            dc.SetBackground(wx.Brush(wx.Colour(30, 60, 40)))  # Match gradient
-            dc.Clear()
-        
-        # Use GraphicsContext for smoother anti-aliased drawing
+        _fill_windows_background(self, dc)
+
         gc = wx.GraphicsContext.Create(dc)
         if not gc:
             return
 
         rect = self.GetClientRect()
-        
-        # 1. Draw Track
-        # We don't clear background, so the parent gradient should show through in empty areas
-        # (assuming the windowing system supports it, which macOS usually does)
-        
-        # Track Color
+        r = min(self.FromDIP(8), rect.height / 2.0, rect.width / 2.0)
+
+        track_path = gc.CreatePath()
+        track_path.AddRoundedRectangle(rect.x, rect.y, rect.width, rect.height, r)
         gc.SetBrush(wx.Brush(self._bg_color))
-        # Transparent pen to avoid border artifacts
-        gc.SetPen(wx.Pen(wx.Colour(0,0,0,0), 1)) 
-        
-        # Draw rounded track
-        corner_radius = 4
-        # Ensure radius isn't too big for the rect
-        r = min(corner_radius, rect.height / 2, rect.width / 2)
-        
-        path = gc.CreatePath()
-        path.AddRoundedRectangle(rect.x, rect.y, rect.width, rect.height, r)
-        gc.DrawPath(path)
-        
-        # 2. Draw Progress
+        gc.SetPen(wx.Pen(wx.Colour(255, 255, 255, 15), 1))
+        gc.DrawPath(track_path)
+
         if self._value > 0 and self._range > 0:
             pct = float(self._value) / float(self._range)
-            w = rect.width * pct
-            
-            # Only draw if width is meaningful
-            if w >= 1:
-                gc.SetBrush(wx.Brush(self._fg_color))
-                gc.SetPen(wx.Pen(wx.Colour(0,0,0,0), 1))
-                
-                path_bar = gc.CreatePath()
-                
-                if w >= rect.width:
-                    # Full width - regular rounded rect
-                    path_bar.AddRoundedRectangle(rect.x, rect.y, rect.width, rect.height, r)
-                else:
-                    # Partially filled - trickier to do "rounded left, square right"
-                    # But for simplicity and aesthetics, a rounded rect clipped or just a rounded rect
-                    # often looks okay if it's just the bar inside the track.
-                    # Let's try to match the track shape.
-                    
-                    # We can intersect the track path with a rectangle of width w
-                    # But clipping in wx.GraphicsContext:
-                    gc.Clip(rect.x, rect.y, w, rect.height)
-                    path_bar.AddRoundedRectangle(rect.x, rect.y, rect.width, rect.height, r)
-                    gc.DrawPath(path_bar)
-                    gc.ResetClip()
-                    return # Done
-                    
-                gc.DrawPath(path_bar)
+            w = max(1.0, rect.width * pct)
+            fill_rect = wx.Rect(rect.x, rect.y, int(w), rect.height)
+            gc.Clip(fill_rect.x, fill_rect.y, fill_rect.width, fill_rect.height)
+
+            glow = Theme.COLOR_PROGRESS_GLOW
+            bar_brush = gc.CreateLinearGradientBrush(
+                rect.x, rect.y, rect.x, rect.y + rect.height,
+                wx.Colour(46, 212, 122),
+                wx.Colour(34, 184, 106),
+            )
+            gc.SetBrush(bar_brush)
+            gc.SetPen(wx.TRANSPARENT_PEN)
+            bar_path = gc.CreatePath()
+            bar_path.AddRoundedRectangle(rect.x, rect.y, rect.width, rect.height, r)
+            gc.DrawPath(bar_path)
+            gc.ResetClip()
+
+            shine = gc.CreatePath()
+            shine.AddRoundedRectangle(rect.x + 1, rect.y + 1, min(w, rect.width) - 2, rect.height * 0.4, r)
+            gc.SetBrush(wx.Brush(wx.Colour(255, 255, 255, 35)))
+            gc.DrawPath(shine)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -200,3 +200,60 @@ def test_align_features_maps_words_to_feature_means(import_audio, tmp_path):
     assert result.loc[0, "f0"] == 3.0
     # "world" spans [0.5, 1.0] -> frames 5.0, 7.0 -> mean 6.0
     assert result.loc[1, "f0"] == 6.0
+
+
+def test_extract_audio_features_batch_cancel_check(import_audio, tmp_path, monkeypatch):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+    processed = []
+
+    def fake_extract(path, progress_callback=None):
+        processed.append(path)
+        return str(tmp_path / f"{os.path.basename(path)}.csv")
+
+    monkeypatch.setattr(processor, "extract_audio_features", fake_extract)
+
+    files = []
+    for i in range(3):
+        wav = tmp_path / f"clip{i}.wav"
+        wav.write_bytes(b"RIFF")
+        files.append(str(wav))
+
+    checks = {"n": 0}
+
+    def cancel_check():
+        checks["n"] += 1
+        return checks["n"] > 1
+
+    processor.extract_audio_features_batch(files, cancel_check=cancel_check)
+    assert len(processed) == 1
+
+
+def test_extract_transcripts_batch_cancel_check(monkeypatch, import_audio, tmp_path):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+    _stub_transcription(processor, audio, monkeypatch, {"text": "hi", "chunks": []})
+
+    files = []
+    for i in range(3):
+        wav = tmp_path / f"clip{i}.wav"
+        wav.write_bytes(b"RIFF")
+        files.append(str(wav))
+
+    transcribed = []
+    original_pipe = processor.whisper_pipe
+
+    def counting_pipe(*args, **kwargs):
+        transcribed.append(args)
+        return original_pipe(*args, **kwargs)
+
+    processor.whisper_pipe = counting_pipe
+
+    checks = {"n": 0}
+
+    def cancel_check():
+        checks["n"] += 1
+        return checks["n"] > 1
+
+    processor.extract_transcripts_batch(files, cancel_check=cancel_check)
+    assert len(transcribed) == 1

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,11 +1,34 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 import types
 
 import numpy as np
 import pandas as pd
+
+
+def _stub_transcription(processor, audio, monkeypatch, result):
+    """Wire a processor so extract_transcripts_batch runs without a real model/audio.
+
+    Returns the dict that captures the ``return_timestamps`` argument the pipeline saw.
+    """
+    captured = {}
+
+    monkeypatch.setattr(processor, "_load_whisper_model", lambda *a, **k: None)
+    monkeypatch.setattr(
+        audio,
+        "_whisper_pipeline_audio_input",
+        lambda path: {"array": np.zeros(4, dtype=np.float32), "sampling_rate": 16000},
+    )
+
+    def fake_pipe(audio_input, return_timestamps=None, generate_kwargs=None):
+        captured["return_timestamps"] = return_timestamps
+        return result
+
+    processor.whisper_pipe = fake_pipe
+    return captured
 
 
 def test_pcm_audio_to_mono_float32_converts_integer_stereo(import_audio):
@@ -89,3 +112,91 @@ def test_extract_audio_features_writes_timestamped_csv(monkeypatch, import_audio
     ]
     assert progress_updates[0] == 0
     assert progress_updates[-1] == 100
+
+
+def _make_processor(audio, tmp_path):
+    return audio.AudioProcessor(
+        output_audio_features_folder=str(tmp_path),
+        output_transcripts_folder=str(tmp_path),
+        status_callback=None,
+        enable_speaker_diarization=False,
+    )
+
+
+def test_extract_transcripts_batch_saves_word_json_when_requested(monkeypatch, import_audio, tmp_path):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+    word_result = {
+        "text": "hello world",
+        "chunks": [
+            {"text": "hello", "timestamp": (0.0, 0.5)},
+            {"text": "world", "timestamp": (0.5, 1.0)},
+        ],
+    }
+    captured = _stub_transcription(processor, audio, monkeypatch, word_result)
+
+    clip = tmp_path / "clip.wav"
+    clip.write_bytes(b"RIFF0000")
+
+    processor.extract_transcripts_batch([str(clip)], word_timestamps=True)
+
+    # Word-level mode was requested at call time...
+    assert captured["return_timestamps"] == "word"
+    # ...the JSON sidecar Align Features needs was written...
+    json_path = tmp_path / "clip_words.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["chunks"][0]["text"] == "hello"
+    # ...and the plain .txt transcript is still produced.
+    assert (tmp_path / "clip.txt").exists()
+
+
+def test_extract_transcripts_batch_segment_mode_writes_no_word_json(monkeypatch, import_audio, tmp_path):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+    captured = _stub_transcription(
+        processor, audio, monkeypatch, {"text": "hello world", "chunks": []}
+    )
+
+    clip = tmp_path / "clip.wav"
+    clip.write_bytes(b"RIFF0000")
+
+    processor.extract_transcripts_batch([str(clip)])  # word_timestamps defaults to False
+
+    assert captured["return_timestamps"] is True
+    assert not (tmp_path / "clip_words.json").exists()
+    assert (tmp_path / "clip.txt").exists()
+
+
+def test_align_features_maps_words_to_feature_means(import_audio, tmp_path):
+    audio = import_audio
+    processor = _make_processor(audio, tmp_path)
+
+    features = pd.DataFrame(
+        {
+            "Timestamp_Seconds": [0.0, 0.25, 0.5, 0.75],
+            "f0": [1.0, 3.0, 5.0, 7.0],
+        }
+    )
+    feature_csv = tmp_path / "clip.csv"
+    features.to_csv(feature_csv, index=False)
+
+    words = {
+        "text": "hello world",
+        "chunks": [
+            {"text": "hello", "timestamp": (0.0, 0.5)},
+            {"text": "world", "timestamp": (0.5, 1.0)},
+        ],
+    }
+    words_json = tmp_path / "clip_words.json"
+    words_json.write_text(json.dumps(words), encoding="utf-8")
+
+    out_csv = tmp_path / "clip_aligned.csv"
+    processor.align_features(str(feature_csv), str(words_json), str(out_csv))
+
+    result = pd.read_csv(out_csv)
+    assert list(result["word"]) == ["hello", "world"]
+    # "hello" spans [0.0, 0.5] -> frames 1.0, 3.0, 5.0 -> mean 3.0
+    assert result.loc[0, "f0"] == 3.0
+    # "world" spans [0.5, 1.0] -> frames 5.0, 7.0 -> mean 6.0
+    assert result.loc[1, "f0"] == 6.0

--- a/tests/test_pose.py
+++ b/tests/test_pose.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+def _install_fake_pose_deps():
+    cv2 = types.ModuleType("cv2")
+
+    class _CapProp:
+        CAP_PROP_FRAME_WIDTH = 3
+        CAP_PROP_FRAME_HEIGHT = 4
+        CAP_PROP_FRAME_COUNT = 7
+        CAP_PROP_FPS = 5
+        CAP_PROP_POS_FRAMES = 1
+        CAP_PROP_POS_AVI_RATIO = 2
+
+    cv2.CAP_PROP_FRAME_WIDTH = 3
+    cv2.CAP_PROP_FRAME_HEIGHT = 4
+    cv2.CAP_PROP_FRAME_COUNT = 7
+    cv2.CAP_PROP_FPS = 5
+    cv2.CAP_PROP_POS_FRAMES = 1
+    cv2.CAP_PROP_POS_AVI_RATIO = 2
+    cv2.COLOR_BGR2RGB = 0
+    cv2.COLOR_GRAY2BGR = 0
+    cv2.COLOR_BGRA2BGR = 0
+    cv2.INTER_AREA = 0
+    cv2.VideoWriter_fourcc = lambda *a: 0
+
+    class FakeVideoCapture:
+        _instances = []
+
+        def __init__(self, path):
+            self.path = path
+            self._index = 0
+            self._max = 20
+            FakeVideoCapture._instances.append(self)
+
+        def isOpened(self):
+            return self._index < self._max
+
+        def read(self):
+            if self._index >= self._max:
+                return False, None
+            frame = np.zeros((48, 64, 3), dtype=np.uint8)
+            self._index += 1
+            return True, frame
+
+        def get(self, prop):
+            if prop == cv2.CAP_PROP_FRAME_COUNT:
+                return self._max
+            if prop == cv2.CAP_PROP_FRAME_WIDTH:
+                return 64
+            if prop == cv2.CAP_PROP_FRAME_HEIGHT:
+                return 48
+            if prop == cv2.CAP_PROP_FPS:
+                return 25
+            return 0
+
+        def set(self, *args, **kwargs):
+            return True
+
+        def release(self):
+            pass
+
+    class FakeVideoWriter:
+        def __init__(self, *args, **kwargs):
+            self.opened = True
+
+        def isOpened(self):
+            return self.opened
+
+        def write(self, frame):
+            return None
+
+        def release(self):
+            self.opened = False
+
+    cv2.VideoCapture = FakeVideoCapture
+    cv2.VideoWriter = FakeVideoWriter
+    cv2.cvtColor = lambda img, code: img
+    cv2.resize = lambda img, size, **kw: img
+
+    mediapipe = types.ModuleType("mediapipe")
+    solutions = types.ModuleType("mediapipe.solutions")
+    pose_mod = types.ModuleType("mediapipe.solutions.pose")
+    drawing_mod = types.ModuleType("mediapipe.solutions.drawing_utils")
+
+    class _Landmarks:
+        landmark = []
+
+    class _Result:
+        pose_landmarks = None
+
+    class _Pose:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def process(self, image_rgb):
+            return _Result()
+
+    class _DrawingSpec:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    pose_mod.Pose = _Pose
+    drawing_mod.draw_landmarks = lambda *a, **k: None
+    drawing_mod.DrawingSpec = _DrawingSpec
+    solutions.pose = pose_mod
+    solutions.drawing_utils = drawing_mod
+    mediapipe.solutions = solutions
+
+    yolov5 = types.ModuleType("yolov5")
+
+    class _YOLO:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def predict(self, *args, **kwargs):
+            return types.SimpleNamespace(xyxy=[[]])
+
+    yolov5.YOLOv5 = _YOLO
+
+    sys.modules["cv2"] = cv2
+    sys.modules["mediapipe"] = mediapipe
+    sys.modules["mediapipe.solutions"] = solutions
+    sys.modules["mediapipe.solutions.pose"] = pose_mod
+    sys.modules["mediapipe.solutions.drawing_utils"] = drawing_mod
+    sys.modules["yolov5"] = yolov5
+
+
+@pytest.fixture
+def import_pose():
+    for name in ("pose", "cv2", "mediapipe", "mediapipe.solutions", "mediapipe.solutions.pose", "mediapipe.solutions.drawing_utils", "yolov5"):
+        sys.modules.pop(name, None)
+    _install_fake_pose_deps()
+    import importlib
+
+    return importlib.import_module("pose")
+
+
+def test_extract_pose_features_cancel_check_stops_early(import_pose, tmp_path, monkeypatch):
+    pose = import_pose
+    monkeypatch.setattr(pose, "ensure_yolov5_weights", lambda: None)
+    processor = pose.PoseProcessor(str(tmp_path))
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake")
+
+    checks = {"n": 0}
+
+    def cancel_check():
+        checks["n"] += 1
+        return checks["n"] > 2
+
+    result = processor.extract_pose_features(str(video), cancel_check=cancel_check)
+    assert result is False
+    assert checks["n"] <= 4
+
+
+def test_embed_pose_video_cancel_check_stops_early(import_pose, tmp_path, monkeypatch):
+    pose = import_pose
+    monkeypatch.setattr(pose, "ensure_yolov5_weights", lambda: None)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    processor = pose.PoseProcessor(str(tmp_path), output_video_folder=str(out_dir))
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake")
+
+    checks = {"n": 0}
+
+    def cancel_check():
+        checks["n"] += 1
+        return checks["n"] > 2
+
+    result = processor.embed_pose_video(str(video), cancel_check=cancel_check)
+    assert result is False


### PR DESCRIPTION
## Summary

Closes #22 
Closes #17 

Supersedes #23 — this branch includes the Align Features word-json fix and additional UI/UX work in one release (`pyproject.toml` **1.1.0**).

### Align Features (from #23)
- **"Save word-level timestamps (for Align Features)"** checkbox on Extract Transcripts → writes `transcripts/{name}_words.json`
- Removes Whisper `max_new_tokens=128` truncation that broke word-level alignment
- Align Features popup lists per-file prep failures instead of a silent "No valid pairs" message

### UI redesign
- Section cards, flat buttons, segmented Video/Audio tabs, centered content column
- Cancel button for long-running batch jobs (video pose, audio features, transcripts, alignment)
- wx sizer fix for header layout on wxPython 4.2.3
- Design system documented in `DESIGN.md`

### Dev/packaging
- `run_app.sh` / `run_app.bat` scrub stale editable-install metadata before reinstall (fixes corrupted `.venv` after cloud sync)
- Release workflow: `UPSTREAM_REPOSITORY` env for publish guard

## Test plan

- [x] `pytest tests/` — 44 passed
- [x] Manual: `run_app.sh` launches on macOS (Complete profile)
- [x] Fork packaging tag before merge: `v1.1.0-test1`